### PR TITLE
Input handling improvements

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -171,18 +171,19 @@ enum _cmds {
 #define AnyCmdActiveR() (cmd_is_activeR(CMD_FIRE) || cmd_is_activeR(CMD_ACTIVATE) || cmd_is_activeR(CMD_TAKEOVER) )
 
 // ----------------------------------------
-
+#define IDX2BIT(i) (1UL << ((unsigned long)(i)))
 typedef enum
 {
-  ACTION_NONE,
-  ACTION_INFO,
-  ACTION_BACK,
-  ACTION_CLICK,
-  ACTION_LEFT,
-  ACTION_RIGHT,
-  ACTION_UP,
-  ACTION_DOWN,
-  ACTION_DELETE
+  ACTION_NONE  = 0,
+  ACTION_INFO  = IDX2BIT(0),
+  ACTION_BACK  = IDX2BIT(1),
+  ACTION_CLICK = IDX2BIT(2),
+  ACTION_LEFT  = IDX2BIT(3),
+  ACTION_RIGHT = IDX2BIT(4),
+  ACTION_UP    = IDX2BIT(5),
+  ACTION_DOWN  = IDX2BIT(6),
+  ACTION_DELETE= IDX2BIT(7),
+  ACTION_LAST  = IDX2BIT(8),
 } MenuAction_t;
 
 #define COLLISION_STEPSIZE   0.1

--- a/src/input.c
+++ b/src/input.c
@@ -769,7 +769,8 @@ any_key_just_pressed (void)
 {
   update_input();
 
-  for (int key=0; key < INPUT_LAST; key++)
+  int key;
+  for (key=0; key < INPUT_LAST; key++)
     {
       if ( just_pressed(input_state[key]) )
         {
@@ -788,7 +789,8 @@ any_key_is_pressedR (void)
 {
   update_input();
 
-  for ( int key=0; key < INPUT_LAST; key ++)
+  int key;
+  for ( key=0; key < INPUT_LAST; key ++)
     {
       if ( (input_state[key] & PRESSED) ) {
         input_state[key] = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -96,16 +96,16 @@ main (int argc, char * argv[])
 	}
 
 
-      // release fire-keys
-      ReleaseKey (CMD_FIRE);
-      ReleaseKey (CMD_ACTIVATE);
-      ReleaseKey (CMD_TAKEOVER);
+      // release all keys
+      wait_for_all_keys_released();
 
       show_droid_info (Me.type, -3, 0);  // show unit-intro page
       show_droid_portrait (Cons_Droid_Rect, Me.type, DROID_ROTATION_TIME, RESET);
       now=SDL_GetTicks();
-      while (  (SDL_GetTicks() - now < SHOW_WAIT) && (!FirePressedR()))
+      while (  (SDL_GetTicks() - now < SHOW_WAIT) && (!FirePressedR())) {
 	show_droid_portrait (Cons_Droid_Rect, Me.type, DROID_ROTATION_TIME, 0);
+        SDL_Delay(1);
+      }
 
       ClearGraphMem();
       DisplayBanner (NULL, NULL, BANNER_FORCE_UPDATE |BANNER_NO_SDL_UPDATE);

--- a/src/menu.c
+++ b/src/menu.c
@@ -661,10 +661,6 @@ const char *handle_QuitGame ( MenuAction_t action )
   MenuItemSelectedSound();
   InitiateMenu (TRUE);
 
-#ifdef ANDROID
-  Terminate (OK);
-#endif
-
 #ifdef GCW0
   PutString (ne_screen, User_Rect.x + User_Rect.w/3,
              User_Rect.y + User_Rect.h/2, "Press A to quit");

--- a/src/menu.c
+++ b/src/menu.c
@@ -840,8 +840,7 @@ ShowMenu ( const MenuEntry_t MenuEntries[] )
   while ( MenuEntries[num_entries].name != NULL ) { num_entries ++; }
 
   InitiateMenu ( FALSE );
-  while ( any_key_is_pressedR() ) // wait for all key/controller-release
-    SDL_Delay(1);
+  wait_for_all_keys_released();
 
   MenuAction_t action = ACTION_NONE;
   const Uint32 wait_move_ticks = 100;
@@ -870,11 +869,16 @@ ShowMenu ( const MenuEntry_t MenuEntries[] )
               PutString (ne_screen, OptionsMenu_Rect.x, Menu_Rect.y + i * fheight, fullName );
             }
           PutInfluence (Menu_Rect.x, Menu_Rect.y + (menu_pos - 0.5) * fheight);
+#ifndef ANDROID
           SDL_Flip( ne_screen );
+#endif
           need_update = FALSE;
         }
-
+#ifdef ANDROID
+      SDL_Flip( ne_screen );	// for responsive input on Android, we need to run this every cycle
+#endif
       action = getMenuAction( 250 );
+
       bool allow_move = ( SDL_GetTicks() - last_move_tick > wait_move_ticks );
       switch ( action )
         {

--- a/src/menu.c
+++ b/src/menu.c
@@ -519,7 +519,8 @@ const char *handle_LE_SizeX ( MenuAction_t action )
   menuChangeInt ( action, &(CurLevel->xlen), 1, 0, MAX_MAP_COLS-1 );
   size_t newmem = CurLevel->xlen * sizeof( CurLevel->map[0][0] );
   // adjust memory sizes for new value
-  for ( int row = 0 ; row < CurLevel->ylen ; row++ )
+  int row;
+  for ( row = 0 ; row < CurLevel->ylen ; row++ )
     {
       CurLevel->map[row] = realloc( CurLevel->map[row], newmem );
       if ( CurLevel->map[row] == NULL ) {
@@ -1155,7 +1156,8 @@ Display_Key_Config (int selx, int sely)
   PrintStringFont (ne_screen, Font0_BFont, col3,   starty + (posy)*lheight, "Key3");
   posy ++;
 
-  for (int i=0; i < CMD_LAST; i++)
+  int i;
+  for (i=0; i < CMD_LAST; i++)
     {
       PrintStringFont (ne_screen, Font0_BFont,  startx, starty+(posy)*lheight, cmd_strings[i]);
       PrintStringFont (ne_screen, PosFont(1,1+i), col1, starty+(posy)*lheight, keystr[key_cmds[i][0]]);

--- a/src/ship.c
+++ b/src/ship.c
@@ -127,6 +127,7 @@ EnterLift (void)
             {
             case ACTION_CLICK:
               finished = TRUE;
+              wait_for_all_keys_released();
               break;
 
             case ACTION_UP:
@@ -346,6 +347,7 @@ EnterKonsole (void)
             {
             case ACTION_BACK:
 	      finished = TRUE;
+              wait_for_all_keys_released();
               break;
 
             case ACTION_UP:
@@ -386,6 +388,7 @@ EnterKonsole (void)
 
             case ACTION_CLICK:
               MenuItemSelectedSound();
+              wait_for_all_keys_released();
               need_update = TRUE;
               switch (pos)
                 {
@@ -406,8 +409,7 @@ EnterKonsole (void)
                   ClearGraphMem();
                   DisplayBanner (NULL, NULL, BANNER_FORCE_UPDATE);
                   ShowLifts (CurLevel->levelnum, -1);
-                  while (! (FirePressedR() || EscapePressedR() || MouseRightPressedR() ))
-                    SDL_Delay(1);
+                  wait_for_key_pressed();
                   PaintConsoleMenu(pos, 0);
                   break;
                 default:
@@ -517,8 +519,7 @@ ShowDeckMap (Level deck)
   Me.pos.x=tmp.x;
   Me.pos.y=tmp.y;
 
-  while (! (FirePressedR() || EscapePressedR() || MouseRightPressedR() ))
-    SDL_Delay(1);
+  wait_for_key_pressed();
 
   SetCombatScaleTo (1.0);
 
@@ -588,6 +589,9 @@ GreatDruidShow (void)
 
   wait_for_all_keys_released();
   bool need_update = TRUE;
+  const Uint32 wait_move_ticks = 100;
+  static Uint32 last_move_tick = 0;
+
   while (!finished)
     {
       show_droid_portrait (Cons_Droid_Rect, droidtype, DROID_ROTATION_TIME, 0);
@@ -604,7 +608,6 @@ GreatDruidShow (void)
       MenuAction_t action = ACTION_NONE;
       // special handling of mouse-clicks: check if move-arrows were clicked on
       if (MouseLeftPressedR ()) {
-        DebugPrintf ( 0, "MouseLeftPress registered\n");
         if ( CursorIsOnRect (&left_rect) ) {
           action = ACTION_LEFT;
         }
@@ -621,41 +624,56 @@ GreatDruidShow (void)
         action = getMenuAction ( 250 );
       }
 
+      bool time_for_move = ( SDL_GetTicks() - last_move_tick > wait_move_ticks );
       switch ( action )
         {
         case ACTION_BACK:
+        case ACTION_CLICK:
           finished = TRUE;
+          wait_for_all_keys_released();
           break;
 
         case ACTION_UP:
+          if ( !time_for_move ) continue;
+
           if ( droidtype < Me.type ) {
             MoveMenuPositionSound();
             droidtype ++;
             need_update = TRUE;
+            last_move_tick = SDL_GetTicks();
           }
           break;
 
         case ACTION_DOWN:
+          if ( !time_for_move ) continue;
+
           if ( droidtype > 0 ) {
             MoveMenuPositionSound();
             droidtype --;
             need_update = TRUE;
+            last_move_tick = SDL_GetTicks();
           }
           break;
 
         case ACTION_RIGHT:
+          if ( !time_for_move ) continue;
+
           if ( page < 2 ) {
             MoveMenuPositionSound();
             page ++;
             need_update = TRUE;
+            last_move_tick = SDL_GetTicks();
           }
           break;
 
         case ACTION_LEFT:
+          if ( !time_for_move ) continue;
+
           if ( page > 0 ) {
             MoveMenuPositionSound();
             page --;
             need_update = TRUE;
+            last_move_tick = SDL_GetTicks();
           }
         default:
           break;

--- a/src/ship.c
+++ b/src/ship.c
@@ -895,12 +895,7 @@ show_droid_portrait (SDL_Rect dst, int droid_type, float cycle_time, int flags)
 
       SDL_UpdateRects (ne_screen, 1, &dst);
 
-      // don't use full CPU unless requested
-      if (!GameConfig.HogCPU)
-	SDL_Delay(1);
-
       last_frame_time = SDL_GetTicks();
-
     }
 
   SDL_SetClipRect (ne_screen, NULL);

--- a/src/takeover.c
+++ b/src/takeover.c
@@ -171,13 +171,17 @@ Takeover (int enemynum)
 
   show_droid_info ( Me.type, -1 , 0);
   show_droid_portrait (Cons_Droid_Rect, Me.type, DROID_ROTATION_TIME, UPDATE);
-  while (!FirePressedR())
+  while (!FirePressedR()) {
     show_droid_portrait (Cons_Droid_Rect, Me.type, DROID_ROTATION_TIME, 0);
+    SDL_Delay(1);
+  }
 
   show_droid_info ( AllEnemys[enemynum].type, -2 ,0);
   show_droid_portrait (Cons_Droid_Rect,  AllEnemys[enemynum].type, DROID_ROTATION_TIME, UPDATE);
-  while (!FirePressedR())
+  while (!FirePressedR()) {
     show_droid_portrait (Cons_Droid_Rect,  AllEnemys[enemynum].type, DROID_ROTATION_TIME, 0);
+    SDL_Delay(1);
+  }
 
   SDL_BlitSurface (takeover_bg_pic, NULL, ne_screen, NULL);
   DisplayBanner (NULL, NULL,  BANNER_FORCE_UPDATE );
@@ -349,6 +353,7 @@ ChooseColor (void)
       if (countdown == 0)
 	ColorChosen = TRUE;
 
+      SDL_Delay(1); // don't hog CPU
     } /* while(!ColorChosen) */
 
   return;
@@ -772,10 +777,6 @@ ShowPlayground (void)
     } /* for player */
 
   SDL_Flip (ne_screen);
-
-  // give CPU some air, unless requested otherwise
-  if (!GameConfig.HogCPU)
-    SDL_Delay(1);
 
   return;
 


### PR DESCRIPTION
finally seem to have figured out the puzzle with Android input sluggishness: need to call SDL_flip() enough for inputs to clear ... => updated all menus, takeover, lifts etc with new unified getMenuActions() and ensure enough calls to SDL_flip() in Android. This now also works much better on PC with keyboard or controller inputs. 