### PR TITLE
17 reduce wait times

### DIFF
--- a/src/BFont.c
+++ b/src/BFont.c
@@ -277,13 +277,13 @@ PutStringFont (SDL_Surface * Surface, BFont_Info * Font, int x, int y, const cha
 
 
 int
-TextWidth (char *text)
+TextWidth (const char *text)
 {
   return TextWidthFont (CurrentFont, text);
 }
 
 int
-TextWidthFont (BFont_Info * Font, char *text)
+TextWidthFont (BFont_Info * Font, const char *text)
 {
   int i = 0, x = 0;
 

--- a/src/BFont.h
+++ b/src/BFont.h
@@ -47,10 +47,10 @@ int PutCharFont (SDL_Surface * Surface, BFont_Info * Font, int x, int y,
 		 int c);
 
 /* Returns the width, in pixels, of the text calculated with the current font*/
-int TextWidth (char *text);
+int TextWidth (const char *text);
 
 /* Returns the width, in pixels, of the text calculated with the specified font*/
-int TextWidthFont (BFont_Info * Font, char *text);
+int TextWidthFont (BFont_Info * Font, const char *text);
 
 /* Write a string on the "Surface" with the current font */
 void PutString (SDL_Surface * Surface, int x, int y, const char *text);

--- a/src/defs.h
+++ b/src/defs.h
@@ -369,7 +369,8 @@ enum _sounds
 #define ENEMYPHASES 		8
 #define DROID_PHASES            ENEMYPHASES
 
-#define WAIT_LEVELEMPTY		1.0  /* warte bevor Graufaerben (in seconds)*/
+#define WAIT_LEVELEMPTY		0.5  /* warte bevor Graufaerben (in seconds)*/
+#define SLOWMO_LEVELEMPTY       0.33  // slow-motion effect on last blast when level is going empty
 #define WAIT_AFTER_KILLED	2000 // time (in ms) to wait and still display pictures after the destruction of
 #define SHOW_WAIT           3500   // std amount of time to show something
                                    // the players droid.  This is now measured in seconds and can be a float

--- a/src/defs.h
+++ b/src/defs.h
@@ -370,7 +370,7 @@ enum _sounds
 #define DROID_PHASES            ENEMYPHASES
 
 #define WAIT_LEVELEMPTY		0.5  /* warte bevor Graufaerben (in seconds)*/
-#define SLOWMO_LEVELEMPTY       0.33  // slow-motion effect on last blast when level is going empty
+#define SLOWMO_FACTOR           0.33  // slow-motion effect on last blast when level is going empty
 #define WAIT_AFTER_KILLED	2000 // time (in ms) to wait and still display pictures after the destruction of
 #define SHOW_WAIT           3500   // std amount of time to show something
                                    // the players droid.  This is now measured in seconds and can be a float

--- a/src/enemy.c
+++ b/src/enemy.c
@@ -573,7 +573,7 @@ MoveThisEnemy( int EnemyNum )
 
 	  CurLevel->empty = TRUE;
 	  CurLevel->timer = WAIT_LEVELEMPTY;
-          set_time_factor ( SLOWMO_LEVELEMPTY );	// watch final explosion in slow-motion
+          set_time_factor ( SLOWMO_FACTOR );	// watch final explosion in slow-motion
 	}
       return;	// this one's down, so we can move on to the next
     }

--- a/src/enemy.c
+++ b/src/enemy.c
@@ -573,6 +573,7 @@ MoveThisEnemy( int EnemyNum )
 
 	  CurLevel->empty = TRUE;
 	  CurLevel->timer = WAIT_LEVELEMPTY;
+          set_time_factor ( SLOWMO_LEVELEMPTY );	// watch final explosion in slow-motion
 	}
       return;	// this one's down, so we can move on to the next
     }

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1206,6 +1206,7 @@ white_noise (SDL_Surface *bitmap, SDL_Rect *rect, int timeout)
 
   now = SDL_GetTicks();
 
+  wait_for_all_keys_released();
   while (1)
     {
       // pick an old enough tile
@@ -1234,6 +1235,10 @@ white_noise (SDL_Surface *bitmap, SDL_Rect *rect, int timeout)
 
       if ( (timeout && (SDL_GetTicks()-now > timeout)))
 	break;
+
+      if ( any_key_just_pressed() ) {
+        break;
+      }
 
     } // while (! finished)
 

--- a/src/highscore.c
+++ b/src/highscore.c
@@ -175,7 +175,10 @@ UpdateHighscores (void)
 #if !defined ANDROID && !defined ARCADEINPUT
   DisplayText ("Enter your name: ",  dst.x - 5*h, dst.y + dst.h, &User_Rect);
 #endif
-#ifdef ARCADEINPUT 
+#ifdef ANDROID
+  wait_for_key_pressed();
+#endif
+#ifdef ARCADEINPUT
   DisplayText ("Enter with U/D, (L/R skip 5 chars),",  dst.x - 6*h, dst.y + dst.h, &User_Rect);
   DisplayText ("Act = toggle case, Fire to enter,",  dst.x - 5*h, dst.y + dst.h + h, &User_Rect);
   DisplayText ("Start when ready: ",  dst.x - 5*h, dst.y + dst.h + h*2, &User_Rect);

--- a/src/influ.c
+++ b/src/influ.c
@@ -788,8 +788,7 @@ CheckInfluenceEnemyCollision (void)
 	  Takeover (i);
 
 	  if (LevelEmpty ())
-	    CurLevel->empty = WAIT_LEVELEMPTY;
-
+	    CurLevel->empty = TRUE;
 	}			/* if !Transfer else .. */
 
     }				/* for */

--- a/src/init.c
+++ b/src/init.c
@@ -630,6 +630,7 @@ InitNewMission ( char *MissionName )
   ThisMessageTime = 0;
   LevelDoorsNotMovedTime = 0.0;
   DeathCount = 0;
+  set_time_factor ( 1.0 );
 
   /* Delete all bullets and blasts */
   for (i = 0; i < MAXBULLETS; i++)
@@ -883,6 +884,7 @@ InitFreedroid (int argc, char *const argv[])
   GameConfig.scale = 1.0;  	 // overall scaling of _all_ graphics (e.g. for 320x200 displays)
 #endif
   GameConfig.HogCPU = FALSE;	// default to being nice
+  GameConfig.emptyLevelSpeedup = 1.5;	// speed up *time* in empty levels (ie also energy-loss rate)
 
   // now load saved options from the config-file
   LoadGameConfig ();

--- a/src/init.c
+++ b/src/init.c
@@ -1031,9 +1031,7 @@ ThouArtVictorious(void)
   Me.status = VICTORY;
   DisplayBanner (NULL, NULL,  BANNER_FORCE_UPDATE );
 
-  // release fire
-  if (FirePressedR())
-    ;
+  wait_for_all_keys_released();
 
   now=SDL_GetTicks();
 
@@ -1054,9 +1052,7 @@ ThouArtVictorious(void)
   SetCurrentFont( Para_BFont);
   ScrollText (DebriefingText , &rect , 6 );
 
-  // release fire
-  if (FirePressedR())
-    ;
+  wait_for_all_keys_released();
 
   return;
 }
@@ -1085,8 +1081,8 @@ ThouArtDefeated (void)
 
   while ( (delay=SDL_GetTicks() - now) < WAIT_AFTER_KILLED)
     {
-      // bit of a dirty hack:  get "slow motion effect" by fiddlig with FPoverSover1
-      FPSover1 *= 2.0;
+      // add "slow motion effect" for final explosion
+      set_time_factor ( SLOWMO_FACTOR );
 
       StartTakingTimeForFPSCalculation();
       DisplayBanner (NULL, NULL,  0 );
@@ -1099,6 +1095,7 @@ ThouArtDefeated (void)
         break;
       }
     }
+  set_time_factor ( 1.0 );
 
 #ifdef HAVE_LIBSDL_MIXER
   Mix_HaltMusic ();

--- a/src/init.c
+++ b/src/init.c
@@ -1077,6 +1077,8 @@ ThouArtDefeated (void)
 
   ExplodeInfluencer ();
 
+  wait_for_all_keys_released();
+
   now = SDL_GetTicks();
 
   while ( (delay=SDL_GetTicks() - now) < WAIT_AFTER_KILLED)
@@ -1091,6 +1093,9 @@ ThouArtDefeated (void)
       MoveEnemys ();
       Assemble_Combat_Picture ( DO_SCREEN_UPDATE );
       ComputeFPSForThisFrame ();
+      if ( any_key_just_pressed() ) {
+        break;
+      }
     }
 
 #ifdef HAVE_LIBSDL_MIXER
@@ -1119,7 +1124,13 @@ ThouArtDefeated (void)
 
   now = SDL_GetTicks ();
 
-  while (SDL_GetTicks() - now < SHOW_WAIT) SDL_Delay(1);
+  wait_for_all_keys_released();
+  while (SDL_GetTicks() - now < SHOW_WAIT) {
+    SDL_Delay(1);
+    if ( any_key_just_pressed() ) {
+      break;
+    }
+  }
 
   UpdateHighscores ();
 

--- a/src/input.c
+++ b/src/input.c
@@ -717,6 +717,9 @@ void
 wait_for_all_keys_released (void)
 {
   while ( any_key_is_pressedR() ) {
+#ifdef ANDROID
+    SDL_Flip(ne_screen);	// make sure we keep updating screen to read out Android inputs
+#endif
     SDL_Delay(1);
   }
   ResetMouseWheel();
@@ -728,6 +731,9 @@ wait_for_key_pressed ( void )
 {
   int key;
   while ( (key = any_key_just_pressed()) == 0 ) {
+#ifdef ANDROID
+    SDL_Flip(ne_screen);	// make sure we keep updating screen to read out Android inputs
+#endif
     SDL_Delay(1);
   }
   return key;

--- a/src/main.c
+++ b/src/main.c
@@ -154,12 +154,23 @@ main (int argc, char * argv[])
 	  CheckInfluenceWallCollisions ();	/* Testen ob der Weg nicht durch Mauern verstellt ist */
 	  CheckInfluenceEnemyCollision ();
 
-
-	  if (CurLevel->empty == TRUE && CurLevel->timer <= 0.0 && CurLevel->color != PD_DARK)
-	    {
-	      CurLevel->color = PD_DARK;
-	      Switch_Background_Music_To (BYCOLOR);  // start new background music
-	    }			/* if */
+          // control speed of time-flow: dark-levels=emptyLevelSpeedup, normal-levels=1.0
+          if ( ! CurLevel->empty )
+            {
+              set_time_factor ( 1.0 );
+            }
+          else
+            {
+              if ( CurLevel->color == PD_DARK )
+                {
+                  set_time_factor ( GameConfig.emptyLevelSpeedup );
+                } // if level is already dark
+              else if ( CurLevel->timer <= 0 ) // time to switch off the lights ...
+                {
+                  CurLevel->color = PD_DARK;
+                  Switch_Background_Music_To (BYCOLOR);  // start new background music
+                } // if wait timer hit 0
+            } // if level empty
 
 	  CheckIfMissionIsComplete ();
 

--- a/src/menu.c
+++ b/src/menu.c
@@ -679,13 +679,16 @@ const char *handle_QuitGame ( MenuAction_t action )
   InitiateMenu (TRUE);
 
 #ifdef GCW0
-  PutString (ne_screen, User_Rect.x + User_Rect.w/3,
-             User_Rect.y + User_Rect.h/2, "Press A to quit");
+  const char *quit_string = "Press A to quit";
 #else
-  PutString (ne_screen, User_Rect.x + User_Rect.w/5,
-             User_Rect.y + User_Rect.h/2, "Hit 'y' or press Fire to quit");
+  const char *quit_string = "Hit 'y' or press Fire to quit";
 #endif
+  int text_width = TextWidth ( quit_string );
+  int text_x = User_Rect.x + (User_Rect.w - text_width)/2;
+  int text_y = User_Rect.y + (User_Rect.h - fheight)/2;
+  PutString (ne_screen, text_x, text_y, quit_string);
   SDL_Flip (ne_screen);
+
 #ifdef GCW0
   while ( (!Gcw0AnyButtonPressed()) ) SDL_Delay(1);
   if ( (Gcw0APressed()) ) {
@@ -859,12 +862,26 @@ getMenuAction ( Uint32 wait_repeat_ticks )
 void
 ShowMenu ( const MenuEntry_t MenuEntries[] )
 {
-  int menu_pos = 0;
-  int num_entries = 0;
-  while ( MenuEntries[num_entries].name != NULL ) { num_entries ++; }
-
   InitiateMenu ( FALSE );
   wait_for_all_keys_released();
+
+  // figure out menu-start point to make it centered
+  int num_entries = 0;
+  int menu_width = 0;
+  int entry_len;
+  while ( MenuEntries[num_entries].name != NULL ) {
+    entry_len = TextWidth ( MenuEntries[num_entries].name );
+    if ( entry_len > menu_width) {
+      menu_width = entry_len;
+    }
+    num_entries ++;
+  }
+  int menu_height = num_entries * fheight;
+  int menu_x = Full_User_Rect.x + (Full_User_Rect.w - menu_width)/2;
+  int menu_y = Full_User_Rect.y + (Full_User_Rect.h - menu_height)/2;
+  int influ_x = menu_x - Block_Rect.w - fheight;
+
+  int menu_pos = 0;
 
   MenuAction_t action = ACTION_NONE;
   const Uint32 wait_move_ticks = 100;
@@ -890,9 +907,9 @@ ShowMenu ( const MenuEntry_t MenuEntries[] )
                 arg = (*MenuEntries[i].handler)( ACTION_INFO );
               }
               sprintf ( fullName, "%s%s", MenuEntries[i].name, (arg == NULL) ? "" : arg );
-              PutString (ne_screen, OptionsMenu_Rect.x, Menu_Rect.y + i * fheight, fullName );
+              PutString (ne_screen, menu_x, menu_y + i * fheight, fullName );
             }
-          PutInfluence (Menu_Rect.x, Menu_Rect.y + (menu_pos - 0.5) * fheight);
+          PutInfluence (influ_x, menu_y + (menu_pos - 0.5) * fheight);
 #ifndef ANDROID
           SDL_Flip( ne_screen );
 #endif

--- a/src/menu.c
+++ b/src/menu.c
@@ -75,6 +75,7 @@ const char *handle_AllMapVisible ( MenuAction_t action );
 const char *handle_ShowDecals ( MenuAction_t action );
 const char *handle_TransferIsActivate ( MenuAction_t action );
 const char *handle_FireIsTransfer ( MenuAction_t action );
+const char *handle_EmptyLevelSpeedup ( MenuAction_t action );
 
 const char *handle_MusicVolume ( MenuAction_t action );
 const char *handle_SoundVolume ( MenuAction_t action );
@@ -121,6 +122,7 @@ MenuEntry_t LegacyMenu[] =
     { "Transfer = Activate: ", 	handle_TransferIsActivate, NULL },
     { "Hold Fire to Transfer: ",handle_FireIsTransfer,	NULL },
 #endif
+    { "Empty Level Speedup: ",  handle_EmptyLevelSpeedup, NULL },
     { NULL,			NULL, 			NULL }
   };
 
@@ -244,6 +246,7 @@ handle_StrictlyClassic ( MenuAction_t action )
       GameConfig.TakeoverActivates = TRUE;
       GameConfig.FireHoldTakeover = TRUE;
       GameConfig.AllMapVisible = TRUE;
+      GameConfig.emptyLevelSpeedup = 1.0;
 
       // set window type
       GameConfig.FullUserRect = FALSE;
@@ -367,11 +370,24 @@ handle_FireIsTransfer ( MenuAction_t action )
 }
 
 const char *
+handle_EmptyLevelSpeedup ( MenuAction_t action )
+{
+  static char buf[256];
+  if ( action == ACTION_INFO ) {
+    sprintf ( buf, "%3.1f" , GameConfig.emptyLevelSpeedup );
+    return buf;
+  }
+
+  menuChangeFloat ( action, &(GameConfig.emptyLevelSpeedup), 0.1, 0.5, 2.0 );
+  return NULL;
+}
+
+const char *
 handle_MusicVolume ( MenuAction_t action )
 {
   static char buf[256];
   if ( action == ACTION_INFO ) {
-    sprintf ( buf, "%1.2f" , GameConfig.Current_BG_Music_Volume );
+    sprintf ( buf, "%4.2f" , GameConfig.Current_BG_Music_Volume );
     return buf;
   }
 
@@ -385,7 +401,7 @@ handle_SoundVolume ( MenuAction_t action )
 {
   static char buf[256];
   if ( action == ACTION_INFO ) {
-    sprintf ( buf, "%1.2f" , GameConfig.Current_Sound_FX_Volume );
+    sprintf ( buf, "%4.2f" , GameConfig.Current_Sound_FX_Volume );
     return buf;
   }
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -52,6 +52,7 @@ long onehundredframedelay = 0;
 Uint32 Now_SDL_Ticks;
 Uint32 One_Frame_SDL_Ticks;
 int framenr = 0;
+static float currentTimeFactor = 1.0;
 
 SDL_Color progress_color = {200, 20, 20};
 
@@ -129,6 +130,7 @@ read_variable (char *data, char *var_name, char *fmt, void *var)
 #define ALL_MAP_VISIBLE              "AllMapVisible"
 #define VID_SCALE_FACTOR             "Vid_ScaleFactor"
 #define HOG_CPU			     "Hog_Cpu"
+#define EMPTY_LEVEL_SPEEDUP          "EmptyLevelSpeedup"
 
 /*----------------------------------------------------------------------
  * LoadGameConfig(): load saved options from config-file
@@ -238,6 +240,7 @@ LoadGameConfig (void)
   read_variable (data, ALL_MAP_VISIBLE,          "%d", &GameConfig.AllMapVisible);
   read_variable (data, VID_SCALE_FACTOR,         "%f", &GameConfig.scale);
   read_variable (data, HOG_CPU,			 "%d", &GameConfig.HogCPU);
+  read_variable (data, EMPTY_LEVEL_SPEEDUP,	 "%f", &GameConfig.emptyLevelSpeedup);
 
   // read in keyboard-config
   for (i=0; i < CMD_LAST; i++)
@@ -295,7 +298,7 @@ SaveGameConfig (void)
   fprintf (fp, "%s = %d\n", ALL_MAP_VISIBLE, GameConfig.AllMapVisible);
   fprintf (fp, "%s = %f\n", VID_SCALE_FACTOR, GameConfig.scale);
   fprintf (fp, "%s = %d\n", HOG_CPU, GameConfig.HogCPU);
-
+  fprintf (fp, "%s = %f\n", EMPTY_LEVEL_SPEEDUP, GameConfig.emptyLevelSpeedup);
 
   // now write the keyboard->cmd mappings
   for (i=0; i < CMD_LAST; i++)
@@ -860,7 +863,7 @@ Frame_Time (void)
     previous_time = (1.0 / FPSover1);
   }
 
-  return (previous_time);
+  return (previous_time * currentTimeFactor);
 
 } // float Frame_Time(void)
 
@@ -1176,5 +1179,13 @@ update_progress (int percent)
   return;
 
 } // update_progress()
+
+// update the factor affecting the current speed of 'time flow'
+void
+set_time_factor ( float timeFactor )
+{
+  currentTimeFactor = timeFactor;
+  return;
+}
 
 #undef _misc_c

--- a/src/proto.h
+++ b/src/proto.h
@@ -286,6 +286,7 @@ EXTERN void *MyMalloc (long);
 EXTERN int FS_filelength (FILE *f);
 EXTERN void init_progress (char *txt);
 EXTERN void update_progress (int percent);
+EXTERN void set_time_factor ( float timeFactor );
 
 /* enemy.c */
 #undef EXTERN

--- a/src/struct.h
+++ b/src/struct.h
@@ -86,6 +86,7 @@ typedef struct
   int AllMapVisible;    		// complete map is visible?
   float scale;  	 		// scale the whole graphics by this at load-time
   int HogCPU;				// use 100% CPU or leave it some air to breathe?
+  float emptyLevelSpeedup;		// time speedup factor to use on empty levels
 }
 config_t;
 

--- a/src/takeover.c
+++ b/src/takeover.c
@@ -211,8 +211,10 @@ Takeover (int enemynum)
       SDL_Flip (ne_screen);
 
       ChooseColor ();
+      wait_for_all_keys_released();
 
       PlayGame ();
+      wait_for_all_keys_released();
 
       /* Ausgang beurteilen und returnen */
       if (InvincibleMode || (LeaderColor == YourColor))
@@ -428,7 +430,12 @@ PlayGame (void)
         {
           do_update_move = FALSE;
           prev_move_tick += move_tick_len; /* set for next motion tick */
-          action = getMenuAction ( 110 );
+#ifndef ANDROID
+          Uint32 key_repeat_delay = 110;	// PC default, allows for quick-repeat key hits
+#else
+          Uint32 key_repeat_delay = 150;	// better to avoid accidential key-repeats on touchscreen
+#endif
+          action = getMenuAction ( key_repeat_delay );
           /* allow for a WIN-key that give immedate victory */
           if ( KeyIsPressedR ('w') && CtrlPressed() && AltPressed() ) {
             LeaderColor = YourColor;   /* simple as that */

--- a/src/takeover.c
+++ b/src/takeover.c
@@ -151,8 +151,6 @@ Takeover (int enemynum)
    */
   Activate_Conservative_Frame_Computation ();
 
-  wait_for_all_keys_released();
-
   // Takeover game always uses Classic User_Rect:
   Copy_Rect (User_Rect, buf);
   Copy_Rect (Classic_User_Rect, User_Rect);
@@ -167,6 +165,8 @@ Takeover (int enemynum)
 
   show_droid_info ( Me.type, -1 , 0);
   show_droid_portrait (Cons_Droid_Rect, Me.type, DROID_ROTATION_TIME, UPDATE);
+
+  wait_for_all_keys_released();
   while (!FirePressedR()) {
     show_droid_portrait (Cons_Droid_Rect, Me.type, DROID_ROTATION_TIME, 0);
     SDL_Delay(1);
@@ -174,6 +174,7 @@ Takeover (int enemynum)
 
   show_droid_info ( AllEnemys[enemynum].type, -2 ,0);
   show_droid_portrait (Cons_Droid_Rect,  AllEnemys[enemynum].type, DROID_ROTATION_TIME, UPDATE);
+  wait_for_all_keys_released();
   while (!FirePressedR()) {
     show_droid_portrait (Cons_Droid_Rect,  AllEnemys[enemynum].type, DROID_ROTATION_TIME, 0);
     SDL_Delay(1);
@@ -182,6 +183,7 @@ Takeover (int enemynum)
   SDL_BlitSurface (takeover_bg_pic, NULL, ne_screen, NULL);
   DisplayBanner (NULL, NULL,  BANNER_FORCE_UPDATE );
 
+  wait_for_all_keys_released();
   while (!FinishTakeover)
     {
       /* Init Color-column and Capsule-Number for each opponenet and your color */
@@ -277,8 +279,14 @@ Takeover (int enemynum)
       ShowPlayground ();
       SDL_Flip (ne_screen);
 
+      wait_for_all_keys_released();
       now = SDL_GetTicks();
-      while ((!FirePressedR()) && (SDL_GetTicks() - now < SHOW_WAIT) ) SDL_Delay(1);
+      while ((!FirePressedR()) && (SDL_GetTicks() - now < SHOW_WAIT) ) {
+#ifdef ANDROID
+        SDL_Flip(ne_screen);
+#endif
+        SDL_Delay(1);
+      }
 
     }	/* while !FinishTakeover */
 
@@ -286,7 +294,6 @@ Takeover (int enemynum)
   Copy_Rect (buf, User_Rect);
 
   ClearGraphMem();
-  SDL_Flip(ne_screen);
 
   if (LeaderColor == YourColor)
     return TRUE;

--- a/src/takeover.c
+++ b/src/takeover.c
@@ -477,9 +477,16 @@ PlayGame (void)
   /* Schluss- Countdown */
   countdown = CAPSULE_COUNTDOWN;
 
+  wait_for_all_keys_released();
+  bool fast_forward = FALSE;
   while (countdown--)
     {
-      while ( SDL_GetTicks() < prev_count_tick + count_tick_len ) ;
+      if ( !fast_forward ) {
+        SDL_Delay ( count_tick_len );
+      }
+      if ( any_key_just_pressed() ) {
+        fast_forward = TRUE;
+      }
       prev_count_tick += count_tick_len;
       ProcessCapsules ();	/* count down the lifetime of the capsules */
       ProcessCapsules ();	/* do it twice this time to be faster */
@@ -490,6 +497,7 @@ PlayGame (void)
       ProcessPlayground ();	/* this has to be done several times to be sure */
       ProcessDisplayColumn ();
       ShowPlayground ();
+      SDL_Delay(1);
       SDL_Flip (ne_screen);
     }	/* while (countdown) */
 


### PR DESCRIPTION
implemented various ideas discussed in #17, allowing clicking-through various wait screens, and speeding up empty levels (configurable).
Also some minor look & feel fine-tuning: center menus, slow-mo effect before level-empty explosion, ... 

@matthiaskrgr given you suggested some of those things: any comments/objections to pushing this?

- refs #17 