### PR TITLE
Bugfix release 1.2.3

### DIFF
--- a/AndroidAppSettings.cfg
+++ b/AndroidAppSettings.cfg
@@ -7,10 +7,10 @@ AppName="Freedroid"
 AppFullName=net.sourceforge.freedroid
 
 # Application version code (integer)
-AppVersionCode=129
+AppVersionCode=130
 
 # Application user-visible version name (string)
-AppVersionName="1.2.2"
+AppVersionName="1.2.3"
 
 # Specify path to download application data in zip archive in the form "Description|URL|MirrorURL^Description2|URL2|MirrorURL2^...'
 # If you'll start Description with '!' symbol it will be enabled by default, '!!' will also hide the entry from the menu, so it cannot be disabled

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Process this file with autoconf to produce a configure script.
-AC_INIT(freedroid, 1.2.2)
+AC_INIT(freedroid, 1.2.3)
 
 dnl Setup for automake
 SDL_VERSION=1.2.3

--- a/map/Paradroid.mission
+++ b/map/Paradroid.mission
@@ -84,7 +84,7 @@ Possible Start Point : Level=7 XPos=2 YPos=1
 
 The title picture in the graphics subdirectory for this mission is : title.jpg
 The title song in the sound subdirectory for this mission is : Paradroid.ogg
-Song name to play in the end title if the mission is completed: android-commando_hiscore.mod
+Song name to play in the end title if the mission is completed: android-commando_hiscore.mod.ogg
 
 
 * New Mission Briefing Text Subsection *

--- a/sound/Makefile.am
+++ b/sound/Makefile.am
@@ -2,7 +2,7 @@ sounddir = $(pkgdatadir)/sound
 
 music = \
 	AnarchyMenu1.mod \
-	android-commando_hiscore.mod \
+	android-commando_hiscore.mod.ogg \
 	dreamfish-green_beret.mod \
 	dreamfish-sanxion.mod \
 	dreamfish-uridium2_loader.mod \

--- a/src/BFont.c
+++ b/src/BFont.c
@@ -12,9 +12,12 @@
 BFont_Info *CurrentFont;
 
 
+void InitFont (BFont_Info * Font);
+
 /* utility functions */
 Uint32 GetPixel (SDL_Surface * Surface, Sint32 X, Sint32 Y);
 void PutPixel (SDL_Surface * surface, int x, int y, Uint32 pixel);
+int count (const char *text);
 
 
 void
@@ -298,7 +301,7 @@ TextWidthFont (BFont_Info * Font, const char *text)
 
 /* counts the spaces of the strings */
 int
-count (char *text)
+count (const char *text)
 {
   char *p = NULL;
   int pos = -1;
@@ -313,14 +316,14 @@ count (char *text)
 }
 
 void
-JustifiedPutString (SDL_Surface * Surface, int y, char *text)
+JustifiedPutString (SDL_Surface * Surface, int y, const char *text)
 {
   JustifiedPutStringFont (Surface, CurrentFont, y, text);
 }
 
 void
 JustifiedPutStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
-			char *text)
+			const char *text)
 {
   int spaces = 0;
   int gap;
@@ -377,12 +380,13 @@ JustifiedPutStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
 		}
 	    }
 	  strtmp = NULL;
+          size_t len = strlen (&text[pos + 1]) + 1;
 	  strtmp =
-	    (char *) calloc (strlen (&text[pos + 1]) + 1, sizeof (char));
+	    (char *) calloc (len, sizeof (char));
 
 	  if (strtmp != NULL)
 	    {
-	      strncpy (strtmp, &text[pos + 1], strlen (&text[pos + 1]));
+	      memcpy (strtmp, &text[pos + 1], len);
 	      PutStringFont (Surface, Font, xpos, y, strtmp);
 	      free (strtmp);
 	    }
@@ -391,42 +395,42 @@ JustifiedPutStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
 }
 
 void
-CenteredPutString (SDL_Surface * Surface, int y, char *text)
+CenteredPutString (SDL_Surface * Surface, int y, const char *text)
 {
   CenteredPutStringFont (Surface, CurrentFont, y, text);
 }
 
 void
 CenteredPutStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
-		       char *text)
+		       const char *text)
 {
   PutStringFont (Surface, Font,
 		 Surface->w / 2 - TextWidthFont (Font, text) / 2, y, text);
 }
 
 void
-RightPutString (SDL_Surface * Surface, int y, char *text)
+RightPutString (SDL_Surface * Surface, int y, const char *text)
 {
   RightPutStringFont (Surface, CurrentFont, y, text);
 }
 
 void
 RightPutStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
-		    char *text)
+		    const char *text)
 {
   PutStringFont (Surface, Font, Surface->w - TextWidthFont (Font, text) - 1,
 		 y, text);
 }
 
 void
-LeftPutString (SDL_Surface * Surface, int y, char *text)
+LeftPutString (SDL_Surface * Surface, int y, const char *text)
 {
   LeftPutStringFont (Surface, CurrentFont, y, text);
 }
 
 void
 LeftPutStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
-		   char *text)
+		   const char *text)
 {
   PutStringFont (Surface, Font, 0, y, text);
 }
@@ -434,7 +438,7 @@ LeftPutStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
 /******/
 
 void
-PrintString (SDL_Surface * Surface, int x, int y, char *fmt, ...)
+PrintString (SDL_Surface * Surface, int x, int y, const char *fmt, ...)
 {
   va_list args;
   char *temp;
@@ -453,7 +457,7 @@ PrintString (SDL_Surface * Surface, int x, int y, char *fmt, ...)
 
 void
 PrintStringFont (SDL_Surface * Surface, BFont_Info * Font, int x, int y,
-		 char *fmt, ...)
+		 const char *fmt, ...)
 {
   va_list args;
   char *temp;
@@ -469,7 +473,7 @@ PrintStringFont (SDL_Surface * Surface, BFont_Info * Font, int x, int y,
 }
 
 void
-CenteredPrintString (SDL_Surface * Surface, int y, char *fmt, ...)
+CenteredPrintString (SDL_Surface * Surface, int y, const char *fmt, ...)
 {
   va_list args;
   char *temp;
@@ -486,7 +490,7 @@ CenteredPrintString (SDL_Surface * Surface, int y, char *fmt, ...)
 
 void
 CenteredPrintStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
-			 char *fmt, ...)
+			 const char *fmt, ...)
 {
   va_list args;
   char *temp;
@@ -503,7 +507,7 @@ CenteredPrintStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
 }
 
 void
-RightPrintString (SDL_Surface * Surface, int y, char *fmt, ...)
+RightPrintString (SDL_Surface * Surface, int y, const char *fmt, ...)
 {
   va_list args;
   char *temp;
@@ -520,7 +524,7 @@ RightPrintString (SDL_Surface * Surface, int y, char *fmt, ...)
 
 void
 RightPrintStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
-		      char *fmt, ...)
+		      const char *fmt, ...)
 {
   va_list args;
   char *temp;
@@ -536,7 +540,7 @@ RightPrintStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
 }
 
 void
-LeftPrintString (SDL_Surface * Surface, int y, char *fmt, ...)
+LeftPrintString (SDL_Surface * Surface, int y, const char *fmt, ...)
 {
   va_list args;
   char *temp;
@@ -553,7 +557,7 @@ LeftPrintString (SDL_Surface * Surface, int y, char *fmt, ...)
 
 void
 LeftPrintStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
-		     char *fmt, ...)
+		     const char *fmt, ...)
 {
   va_list args;
   char *temp;
@@ -569,7 +573,7 @@ LeftPrintStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
 }
 
 void
-JustifiedPrintString (SDL_Surface * Surface, int y, char *fmt, ...)
+JustifiedPrintString (SDL_Surface * Surface, int y, const char *fmt, ...)
 {
   va_list args;
   char *temp;
@@ -586,7 +590,7 @@ JustifiedPrintString (SDL_Surface * Surface, int y, char *fmt, ...)
 
 void
 JustifiedPrintStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
-			  char *fmt, ...)
+			  const char *fmt, ...)
 {
   va_list args;
   char *temp;

--- a/src/BFont.h
+++ b/src/BFont.h
@@ -59,55 +59,55 @@ void PutString (SDL_Surface * Surface, int x, int y, const char *text);
 void PutStringFont (SDL_Surface * Surface, BFont_Info * Font, int x, int y, const char *text);
 
 /* Write a left-aligned string on the "Surface" with the current font */
-void LeftPutString (SDL_Surface * Surface, int y, char *text);
+void LeftPutString (SDL_Surface * Surface, int y, const char *text);
 
 /* Write a left-aligned string on the "Surface" with the specified font */
 void LeftPutStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
-			char *text);
+			const char *text);
 
 /* Write a center-aligned string on the "Surface" with the current font */
-void CenteredPutString (SDL_Surface * Surface, int y, char *text);
+void CenteredPutString (SDL_Surface * Surface, int y, const char *text);
 
 /* Write a center-aligned string on the "Surface" with the specified font */
 void CenteredPutStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
-			    char *text);
+			    const char *text);
 
 /* Write a right-aligned string on the "Surface" with the specified font */
-void RightPutString (SDL_Surface * Surface, int y, char *text);
+void RightPutString (SDL_Surface * Surface, int y, const char *text);
 
 /* Write a right-aligned string on the "Surface" with the specified font */
 void RightPutStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
-			 char *text);
+			 const char *text);
 
 /* Write a justify-aligned string on the "Surface" with the specified font */
-void JustifiedPutString (SDL_Surface * Surface, int y, char *text);
+void JustifiedPutString (SDL_Surface * Surface, int y, const char *text);
 
 /* Write a justify-aligned string on the "Surface" with the specified font */
 void JustifiedPutStringFont (SDL_Surface * Surface, BFont_Info * Font,
-			     int y, char *text);
+			     int y, const char *text);
 
 
 /* The following functions do the same task but have the classic "printf" sintax */
 
-void PrintString (SDL_Surface * Surface, int x, int y, char *fmt, ...);
+void PrintString (SDL_Surface * Surface, int x, int y, const char *fmt, ...);
 void PrintStringFont (SDL_Surface * Surface, BFont_Info * Font, int x,
-		      int y, char *fmt, ...);
+		      int y, const char *fmt, ...);
 
-void CenteredPrintString (SDL_Surface * Surface, int y, char *fmt, ...);
+void CenteredPrintString (SDL_Surface * Surface, int y, const char *fmt, ...);
 void CenteredPrintStringFont (SDL_Surface * Surface, BFont_Info * Font,
-			      int y, char *fmt, ...);
+			      int y, const char *fmt, ...);
 
-void RightPrintString (SDL_Surface * Surface, int y, char *fmt, ...);
+void RightPrintString (SDL_Surface * Surface, int y, const char *fmt, ...);
 void RightPrintStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
-			   char *fmt, ...);
+			   const char *fmt, ...);
 
-void LeftPrintString (SDL_Surface * Surface, int y, char *fmt, ...);
+void LeftPrintString (SDL_Surface * Surface, int y, const char *fmt, ...);
 void LeftPrintStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
-			  char *fmt, ...);
+			  const char *fmt, ...);
 
-void JustifiedPrintString (SDL_Surface * Surface, int y, char *fmt, ...);
+void JustifiedPrintString (SDL_Surface * Surface, int y, const char *fmt, ...);
 void JustifiedPrintStringFont (SDL_Surface * Surface, BFont_Info * Font,
-			       int y, char *fmt, ...);
+			       int y, const char *fmt, ...);
 
 /* Returns a new font colored with the color (r,g,b) */
 BFont_Info *SetFontColor (BFont_Info * Font, Uint8 r, Uint8 g, Uint8 b);

--- a/src/bullet.c
+++ b/src/bullet.c
@@ -48,6 +48,10 @@
 #define DRUIDHITDIST2		(0.3+MORE)*(Droid_Radius+MORE)
 // #define DRUIDHITDIST2		0
 
+// local prototypes
+int GetDirection (point robo, point bul);
+
+
 
 /*@Function============================================================
 @Desc: this function moves all the bullets according to their speeds.
@@ -271,7 +275,7 @@ GetDirection (point robo, point bul)
 void
 CheckBulletCollisions (int num)
 {
-  int level = CurLevel->levelnum;
+  int levelnum = CurLevel->levelnum;
   float xdist, ydist;
   Bullet CurBullet = &AllBullets[num];
   static int FBTZaehler = 0;
@@ -315,7 +319,7 @@ CheckBulletCollisions (int num)
       for (i = 0; i < NumEnemys; i++)
 	{
 	  // !! dont't forget: Only droids on our level are harmed!! (bugfix)
-	  if (AllEnemys[i].levelnum != level)
+	  if (AllEnemys[i].levelnum != levelnum)
 	    continue;
 
 	  if ( IsVisible (&AllEnemys[i].pos) & (!Druidmap[AllEnemys[i].type].flashimmune) )
@@ -388,7 +392,7 @@ CheckBulletCollisions (int num)
 	  for (i = 0; i < NumEnemys; i++)
 	    {
 	      if (AllEnemys[i].status == OUT || AllEnemys[i].status == TERMINATED ||
-		  AllEnemys[i].levelnum != level)
+		  AllEnemys[i].levelnum != levelnum)
 		continue;
 
 	      xdist = CurBullet->pos.x - AllEnemys[i].pos.x;
@@ -454,7 +458,7 @@ void
 CheckBlastCollisions (int num)
 {
   int i;
-  int level = CurLevel->levelnum;
+  int levelnum = CurLevel->levelnum;
   Blast CurBlast = &(AllBlasts[num]);
   Bullet CurBullet;
   float dist;
@@ -482,7 +486,7 @@ CheckBlastCollisions (int num)
   for (i = 0; i < NumEnemys; i++)
     {
       if ((AllEnemys[i].status == OUT)
-	  || (AllEnemys[i].levelnum != level))
+	  || (AllEnemys[i].levelnum != levelnum))
 	continue;
 
       vdist.x = AllEnemys[i].pos.x - CurBlast->PX;

--- a/src/defs.h
+++ b/src/defs.h
@@ -61,6 +61,8 @@
 
 #define FreeIfUsed(pt) do { if ((pt)) SDL_FreeSurface((pt)); } while(0)
 
+#define NUM_ELEM(x) ( sizeof((x)) / sizeof((x)[0]) )
+
 // ----------------------------------------
 // some input-related defines and macros
 

--- a/src/enemy.c
+++ b/src/enemy.c
@@ -46,18 +46,28 @@
 #define FIREDIST2	8 // according to the intro, the laser can be "focused on any target
                           // within a range of eight metres"
 
+// local prototypes
+void CheckDroidDistribution (int levelnum);
+int DirectLineWalkable( float x1 , float y1 , float x2 , float y2 );
+void PermanentHealRobots (void);
+void SelectNextWaypointClassical( int EnemyNum );
+int CheckIfWayIsFreeOfDroids ( float x1 , float y1 , float x2 , float y2 , int OurLevel , int ExceptedDroid );
+void MoveThisRobotThowardsHisWaypoint ( int EnemyNum );
+void SelectNextWaypointAdvanced ( int EnemyNum );
+void MoveThisEnemy( int EnemyNum );
+
 
 //----------------------------------------------------------------------
 // for debug purposes: check if there are any droid "piles" on this level
 //----------------------------------------------------------------------
 void
-CheckDroidDistribution (int level)
+CheckDroidDistribution (int levelnum)
 {
   int i;
   bool ok = TRUE;
 
   for (i=0; i< NumEnemys; i++)
-    if ( (AllEnemys[i].levelnum == level) && CheckEnemyEnemyCollision (i) )
+    if ( (AllEnemys[i].levelnum == levelnum) && CheckEnemyEnemyCollision (i) )
       {
 	DebugPrintf (0, "We found a droid collision of droid Nr: %d\n", i);
 	ok = FALSE;

--- a/src/global.h
+++ b/src/global.h
@@ -77,16 +77,16 @@ EXTERN SDL_Rect ProgressText_Rect;
 EXTERN float LastRefreshSound;
 EXTERN float LastGotIntoBlastSound;
 EXTERN float FPSover1;
-EXTERN char *Alertcolor[AL_LAST];
-EXTERN char *Shipnames[ALLSHIPS];
+EXTERN const char *Alertcolor[AL_LAST];
+EXTERN const char *Shipnames[ALLSHIPS];
 
-EXTERN char *Classname[];
-EXTERN char *Classes[];
-EXTERN char *Weaponnames[];
-EXTERN char *Sensornames[];
-EXTERN char *Brainnames[];
-EXTERN char *Drivenames[];
-EXTERN char *InfluenceModeNames[];
+EXTERN const char *Classname[];
+EXTERN const char *Classes[];
+EXTERN const char *Weaponnames[];
+EXTERN const char *Sensornames[];
+EXTERN const char *Brainnames[];
+EXTERN const char *Drivenames[];
+EXTERN const char *InfluenceModeNames[];
 EXTERN int ThisMessageTime;
 
 EXTERN influence_t Me;		/* the influence data */

--- a/src/highscore.c
+++ b/src/highscore.c
@@ -199,7 +199,12 @@ UpdateHighscores (void)
 
   tsec = time (NULL);
   timeinfo = gmtime (&tsec);
-  sprintf (new_entry->date, "20%02d/%02d/%02d", timeinfo->tm_year - 100, timeinfo->tm_mon +1, timeinfo->tm_mday );
+  size_t written = snprintf (new_entry->date, sizeof(new_entry->date), "20%02d/%02d/%02d",
+                          timeinfo->tm_year - 100, timeinfo->tm_mon +1, timeinfo->tm_mday );
+  if (written >= sizeof(new_entry->date))
+    {
+      DebugPrintf (0, "WARNING: truncated date entry?! %zd >= %zd?!", written, sizeof(new_entry->date) );
+    }
 
   new_entry->score = score;
   Highscores[entry] = new_entry;

--- a/src/input.c
+++ b/src/input.c
@@ -55,8 +55,6 @@ Uint32 last_mouse_event = 0;  // record when last mouse event took place (SDL ti
 
 SDLMod current_modifiers;
 
-SDL_Event event;
-
 int input_state[INPUT_LAST];	// array of states (pressed/released) of all keys
 
 int key_cmds[CMD_LAST][3] =  // array of mappings {key1,key2,key3 -> cmd}
@@ -92,9 +90,9 @@ int key_cmds[CMD_LAST][3] =  // array of mappings {key1,key2,key3 -> cmd}
 #endif
   };
 
-char *keystr[INPUT_LAST];
+const char *keystr[INPUT_LAST];
 
-char *cmd_strings[CMD_LAST] =
+const char *cmd_strings[CMD_LAST] =
   {
     "UP",
     "DOWN",
@@ -122,6 +120,8 @@ char *cmd_strings[CMD_LAST] =
 
 #define clear_fresh(x) do { (x) &= ~FRESH_BIT; } while(0)
 
+// local prototypes
+int sgn (int x);
 
 void
 init_keystr (void)
@@ -383,7 +383,8 @@ int
 update_input (void)
 {
   Uint8 axis;
-
+  SDL_Event event;
+  
   // switch mouse-cursor visibility as a function of time of last activity
   if (SDL_GetTicks () - last_mouse_event > CURSOR_KEEP_VISIBLE)
     show_cursor = FALSE;

--- a/src/level_editor.c
+++ b/src/level_editor.c
@@ -46,6 +46,7 @@
 void Show_Waypoints(void);
 void DeleteWaypoint (level *level, int num);
 void CreateWaypoint (level *level, int BlockX, int BlockY);
+void Highlight_Current_Block(void);
 
 
 // ----- function definitions --------------------
@@ -219,7 +220,7 @@ LevelEditor(void)
   int OriginWaypoint = (-1);
   char* NumericInputString;
   SDL_Rect rect;
-  waypoint *SrcWp;
+  waypoint *SrcWp = NULL;
 
   int KeymapOffset = 15;
 

--- a/src/main.c
+++ b/src/main.c
@@ -57,7 +57,6 @@ void UpdateCountersForThisFrame (void);
 int
 main (int argc, char * argv[])
 {
-  int i, level;
   Uint32 now;
   float scale;
 
@@ -88,10 +87,10 @@ main (int argc, char * argv[])
       // scale Level-pic rects
       if ( (scale = GameConfig.scale) != 1.0)
 	{
-	  for (level = 0; level < curShip.num_levels; level++)
-	    for (i=0; i<curShip.num_level_rects[level]; i++)
-	      ScaleRect (curShip.Level_Rects[level][i], scale);
-	  for (i=0; i < curShip.num_lift_rows; i++)
+	  for (int levelnum = 0; levelnum < curShip.num_levels; levelnum++)
+	    for (int i=0; i<curShip.num_level_rects[levelnum]; i++)
+	      ScaleRect (curShip.Level_Rects[levelnum][i], scale);
+	  for (int i=0; i < curShip.num_lift_rows; i++)
 	    ScaleRect (curShip.LiftRow_Rect[i], scale);
 	}
 
@@ -141,7 +140,7 @@ main (int argc, char * argv[])
 
 	  Assemble_Combat_Picture ( DO_SCREEN_UPDATE );
 
-	  for (i = 0; i < MAXBULLETS; i++) CheckBulletCollisions (i);
+	  for (int i = 0; i < MAXBULLETS; i++) CheckBulletCollisions (i);
 
 	  MoveInfluence ();	// change Influ-speed depending on keys pressed, but
 	                        // also change his status and position and "phase" of rotation
@@ -199,8 +198,6 @@ function.
 void
 UpdateCountersForThisFrame (void)
 {
-  int i;
-
   // Here are some things, that were previously done by some periodic */
   // interrupt function
   ThisMessageTime++;
@@ -241,7 +238,7 @@ UpdateCountersForThisFrame (void)
   RealScore += AlertLevel * AlertBonusPerSec * Frame_Time();
 
 
-  for (i = 0; i < MAX_ENEMYS_ON_SHIP ; i++)
+  for (int i = 0; i < MAX_ENEMYS_ON_SHIP ; i++)
     {
 
       if (AllEnemys[i].status == OUT ) continue;

--- a/src/map.c
+++ b/src/map.c
@@ -51,7 +51,11 @@
 #define BACKGROUND_SONG_NAME_STRING "Name of background song for this level="
 
 void ResetLevelMap (Level Lev);
-void GetThisLevelsDroids( char* SectionPointer );
+void GetThisLevelsDroids( const char* SectionPointer );
+char *StructToMem(Level Lev);
+void GetAlerts (Level Lev);
+int IsWallBlock (int block);
+
 
 /*@Function============================================================
   @Desc: unsigned char GetMapBrick(Level deck, float x, float y): liefert
@@ -311,7 +315,7 @@ char *StructToMem(Level Lev)
 {
   char *LevelMem;
   int i, j;
-  int MemAmount=0;		/* the size of the level-data */
+  size_t MemAmount=0;		/* the size of the level-data */
   int xlen = Lev->xlen, ylen = Lev->ylen;
   int anz_wp;		/* number of Waypoints */
   char linebuf[500];		/* Buffer */
@@ -409,7 +413,7 @@ char *StructToMem(Level Lev)
 int SaveShip( const char *shipname)
 {
   char *LevelMem;		/* linear memory for one Level */
-  char *MapHeaderString;
+  const char *MapHeaderString;
   FILE *ShipFile;  // to this file we will save all the ship data...
   char filename[FILENAME_LEN+1];
   int level_anz;
@@ -1162,10 +1166,10 @@ to the specifications made in the file.
 ----------------------------------------------------------------------
 */
 void
-GetThisLevelsDroids( char* SectionPointer )
+GetThisLevelsDroids( const char* SectionPointer )
 {
   int OurLevelNumber;
-  char* SearchPointer;
+  const char* SearchPointer;
   char* EndOfThisLevelData;
   int MaxRand;
   int MinRand;

--- a/src/map.h
+++ b/src/map.h
@@ -97,7 +97,7 @@ enum _colornames
 #if  (defined _gen_c) || (defined _map_c)
 
 /* Color - names */
-char *ColorNames[] = {
+const char *ColorNames[] = {
   "Red",
   "Yellow",
   "Green",
@@ -107,7 +107,7 @@ char *ColorNames[] = {
   "Dark"
 };
 
-int numLevelColors = sizeof(ColorNames)/sizeof(ColorNames[0]);
+int numLevelColors = NUM_ELEM(ColorNames);
 #else
 extern char *ColorNames[];
 extern int numLevelColors;

--- a/src/menu.c
+++ b/src/menu.c
@@ -55,7 +55,7 @@ int fheight;  // font height of Menu-font
 typedef struct MenuEntry_s
 {
   const char *name;			/**< menu entry string */
-  const char *(*handler)();		/**< handler & info function for this menu entry (none if NULL) */
+  const char *(*handler)(MenuAction_t action);	/**< handler & info function for this menu entry (none if NULL) */
   const struct MenuEntry_s *submenu; 	/**< enter this submenu (if non-NULL) */
 } MenuEntry_t;
 
@@ -1243,7 +1243,7 @@ Cheatmenu (void)
   int x0, y0;
   Waypoint WpList;      /* pointer on current waypoint-list  */
   BFont_Info *font;
-  char *status;
+  const char *status;
 
   // Prevent distortion of framerate by the delay coming from
   // the time spend in the menu.
@@ -1452,7 +1452,7 @@ Cheatmenu (void)
 	  input = GetString (40, 2);
 	  sscanf (input, "%d", &LNum);
 	  free (input);
-	  ShowDeckMap (curShip.AllLevels[LNum]);
+	  ShowDeckMap ();
 	  getchar_raw ();
 	  break;
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -42,9 +42,9 @@
 #include "global.h"
 #include "proto.h"
 
-int read_variable (char *data, char *var_name, char *fmt, void *var);
+int read_variable (char *data, const char *var_name, const char *fmt, void *var);
 
-char *homedir = NULL;
+const char *homedir = NULL;
 
 long oneframedelay = 0;
 long tenframedelay = 0;
@@ -54,7 +54,7 @@ Uint32 One_Frame_SDL_Ticks;
 int framenr = 0;
 static float currentTimeFactor = 1.0;
 
-SDL_Color progress_color = {200, 20, 20};
+SDL_Color progress_color = {.r = 200, .g = 20, .b = 20};
 
 extern int key_cmds[CMD_LAST][3];
 extern char *cmd_strings[CMD_LAST];
@@ -79,7 +79,7 @@ int sign (float x)
 // returns ERR if not found or could not be read, OK if found&read
 // ----------------------------------------------------------------------
 int
-read_variable (char *data, char *var_name, char *fmt, void *var)
+read_variable (char *data, const char *var_name, const char *fmt, void *var)
 {
   char *found = NULL;
   int ret;
@@ -320,7 +320,7 @@ it, copys it there and returns it.
 The original source string specified should in no way be modified.
 ----------------------------------------------------------------------*/
 char*
-ReadAndMallocStringFromData ( char* SearchString , char* StartIndicationString , char* EndIndicationString )
+ReadAndMallocStringFromData ( const char* SearchString , const char* StartIndicationString , const char* EndIndicationString )
 {
   char* SearchPointer;
   char* EndOfStringPointer;
@@ -402,10 +402,10 @@ other string.
 ----------------------------------------------------------------------
 */
 int
-CountStringOccurences ( char* SearchString , char* TargetString )
+CountStringOccurences ( const char* SearchString , const char* TargetString )
 {
   int Counter=0;
-  char* CountPointer;
+  const char* CountPointer;
 
   CountPointer = SearchString;
 
@@ -426,7 +426,7 @@ can easily be treated like a common string.
 ----------------------------------------------------------------------
 */
 char*
-ReadAndMallocAndTerminateFile( char* filename , char* File_End_String )
+ReadAndMallocAndTerminateFile( const char* filename , const char* File_End_String )
 {
   struct stat stbuf;
   FILE *DataFile;
@@ -553,7 +553,7 @@ we are searching is found in the main text.
 ----------------------------------------------------------------------
 */
 char*
-LocateStringInData ( char* SearchBeginPointer, char* SearchTextPointer )
+LocateStringInData ( const char* SearchBeginPointer, const char* SearchTextPointer )
 {
   char* temp;
 
@@ -599,7 +599,7 @@ not resolve.... Sorry, if that interrupts a major game of yours.....\n\
  *
  *----------------------------------------------------------------------*/
 void
-ReadValueFromString (char* data, char* label, char* FormatString, void* dst)
+ReadValueFromString (const char* data, const char* label, const char* FormatString, void* dst)
 {
   char *pos;
 
@@ -639,7 +639,7 @@ ReadValueFromString (char* data, char* label, char* FormatString, void* dst)
  *
  *-----------------------------------------------------------------*/
 char *
-find_file (const char *fname, char *subdir, int use_theme, int critical)
+find_file (const char *fname, const char *subdir, int use_theme, int critical)
 {
   static char File_Path[2048] = "";   /* hope this will be enough */
   int len = sizeof(File_Path);
@@ -708,9 +708,11 @@ find_file (const char *fname, char *subdir, int use_theme, int critical)
 	    DebugPrintf (0, " in theme-dir: graphics/%s_theme/ \n", GameConfig.Theme_Name);
 	  DebugPrintf (0, "...cannot run without it!\n");
 	  Terminate (ERR);
+          break;
 	default:
 	  DebugPrintf (0, "ERROR in find_file(): Code should never reach this line!! Harakiri\n");
 	  Terminate (ERR);
+          break;
 	}
     }
 
@@ -909,7 +911,7 @@ Activate_Conservative_Frame_Computation(void)
 @Ret: none
 * $Function----------------------------------------------------------*/
 void
-DebugPrintf (int db_level, char *fmt, ...)
+DebugPrintf (int db_level, const char *fmt, ...)
 {
   va_list args;
   static char buffer[5000+1];
@@ -1100,7 +1102,7 @@ MyMalloc (long Mamount)
  * FS_filelength().. (taken from quake2)
  * 		contrary to stat() this fct is nice and portable,
  *----------------------------------------------------------------------*/
-int
+size_t
 FS_filelength (FILE *f)
 {
   int		pos;
@@ -1118,7 +1120,7 @@ FS_filelength (FILE *f)
  * show_progress: display empty progress meter with given text
  *----------------------------------------------------------------------*/
 void
-init_progress (char *text)
+init_progress (const char *text)
 {
   char *fpath;
   SDL_Rect dst;

--- a/src/proto.h
+++ b/src/proto.h
@@ -45,9 +45,9 @@ EXTERN int ShipEmptyCounter;
 #define EXTERN extern
 #endif
 EXTERN void parse_command_line (int argc, char *const argv[]);
-EXTERN void Title ( char *MissionBriefingPointer );
+EXTERN void Title ( const char *MissionBriefingPointer );
 EXTERN void InitFreedroid (int argc, char *const argv[]);
-EXTERN void InitNewMission (char *MissionName);
+EXTERN void InitNewMission (const char *MissionName);
 EXTERN void CheckIfMissionIsComplete (void);
 EXTERN void ThouArtDefeated (void);
 EXTERN void ThouArtVictorious (void);
@@ -266,12 +266,12 @@ EXTERN void FreeMenuData ( void );
 EXTERN int LoadGameConfig (void);
 EXTERN int SaveGameConfig (void);
 EXTERN int sign (float x);
-EXTERN char* ReadAndMallocStringFromData ( char* SearchString , char* StartIndicationString , char* EndIndicationString );
-EXTERN int CountStringOccurences ( char* SearchString , char* TargetString ) ;
-EXTERN void ReadValueFromString(char* data, char* label, char* FormatString, void* dst);
-EXTERN char* ReadAndMallocAndTerminateFile( char* filename , char* File_End_String ) ;
-EXTERN char* LocateStringInData ( char* SearchBeginPointer, char* SearchTextPointer ) ;
-EXTERN char* find_file (const char *fname, char *subdir, int use_theme, int critical);
+EXTERN char* ReadAndMallocStringFromData ( const char* SearchString , const char* StartIndicationString , const char* EndIndicationString );
+EXTERN int CountStringOccurences ( const char* SearchString , const char* TargetString ) ;
+EXTERN void ReadValueFromString(const char* data, const char* label, const char* FormatString, void* dst);
+EXTERN char* ReadAndMallocAndTerminateFile( const char* filename , const char* File_End_String ) ;
+EXTERN char* LocateStringInData ( const char* SearchBeginPointer, const char* SearchTextPointer ) ;
+EXTERN char* find_file (const char *fname, const char *subdir, int use_theme, int critical);
 EXTERN void CheckForTriggeredEvents ( void );
 EXTERN void Pause (void);
 EXTERN void ComputeFPSForThisFrame(void);
@@ -279,14 +279,14 @@ EXTERN void StartTakingTimeForFPSCalculation(void);
 EXTERN int Get_Average_FPS ( void );
 EXTERN float Frame_Time (void);
 EXTERN void Activate_Conservative_Frame_Computation(void);
-EXTERN void DebugPrintf (int db_level, char *fmt, ...);
+EXTERN void DebugPrintf (int db_level, const char *fmt, ...);
 EXTERN int MyRandom (int);
 EXTERN void Armageddon (void);
 EXTERN void Teleport (int LNum, int X, int Y);
 EXTERN void Terminate (int);
 EXTERN void *MyMalloc (long);
-EXTERN int FS_filelength (FILE *f);
-EXTERN void init_progress (char *txt);
+EXTERN size_t FS_filelength (FILE *f);
+EXTERN void init_progress (const char *txt);
 EXTERN void update_progress (int percent);
 EXTERN void set_time_factor ( float timeFactor );
 
@@ -313,7 +313,7 @@ EXTERN int ClassOfDruid (int druidtype);
 #else
 #define EXTERN extern
 #endif
-EXTERN void ShowDeckMap (Level deck);
+EXTERN void ShowDeckMap (void);
 EXTERN void EnterLift (void);
 EXTERN void EnterKonsole (void);
 EXTERN int LevelEmpty (void);
@@ -339,10 +339,10 @@ EXTERN void AddInfluBurntText( void );
 EXTERN void AddStandingAndAimingText ( int Enum );
 EXTERN int DisplayText (const char *text, int startx, int starty, const SDL_Rect *clip);
 EXTERN void DisplayChar (unsigned char c);
-EXTERN int ScrollText (char *Text, SDL_Rect *rect , int SecondsMinimumDuration );
+EXTERN int ScrollText (char *Text, SDL_Rect *rect);
 EXTERN bool linebreak_needed (const char *textpos , const SDL_Rect *clip);
 EXTERN char *GetString (int MaxLen, int echo);
-EXTERN void printf_SDL (SDL_Surface *screen, int x, int y, char *fmt, ...);
+EXTERN void printf_SDL (SDL_Surface *screen, int x, int y, const char *fmt, ...);
 EXTERN int putchar_SDL (SDL_Surface *Surface, int x, int y, int c);
 
 /* takeover.c */
@@ -359,7 +359,7 @@ EXTERN void PlayGame (void);
 EXTERN void EnemyMovements (void);
 
 EXTERN int set_takeover_rects (void);
-EXTERN void ShowPlayground ();
+EXTERN void ShowPlayground (void);
 EXTERN void InventPlayground (void);
 
 EXTERN void ProcessPlayground (void);

--- a/src/ship.c
+++ b/src/ship.c
@@ -239,11 +239,11 @@ EnterLift (void)
  *
  *-----------------------------------------------------------------*/
 void
-ShowLifts (int level, int liftrow)
+ShowLifts (int levelnum, int liftrow)
 {
   SDL_Rect src, dst;
   int i;
-  SDL_Color lift_bg_color = {0,0,0};  /* black... */
+  SDL_Color lift_bg_color = {.r = 0,.g = 0, .b = 0};  /* black... */
   int xoffs = User_Rect.w/20;
   int yoffs = User_Rect.h/5;
 
@@ -259,10 +259,10 @@ ShowLifts (int level, int liftrow)
   dst.y += yoffs;
   SDL_BlitSurface (ship_off_pic, NULL, ne_screen, &dst);
 
-  if (level >= 0)
-    for (i=0; i<curShip.num_level_rects[level]; i++)
+  if (levelnum >= 0)
+    for (i=0; i<curShip.num_level_rects[levelnum]; i++)
       {
-	Copy_Rect (curShip.Level_Rects[level][i], src);
+	Copy_Rect (curShip.Level_Rects[levelnum][i], src);
 	Copy_Rect (src, dst);
 	dst.x += User_Rect.x + xoffs;   /* offset respective to User-Rectangle */
 	dst.y += User_Rect.y + yoffs;
@@ -402,7 +402,7 @@ EnterKonsole (void)
                 case 2:
                   ClearGraphMem();
                   DisplayBanner (NULL, NULL, BANNER_FORCE_UPDATE);
-                  ShowDeckMap (CurLevel);
+                  ShowDeckMap ();
                   PaintConsoleMenu(pos, 0);
                   break;
                 case 3:
@@ -499,7 +499,7 @@ PaintConsoleMenu (int pos, int flag)
  *            immediately
  *-----------------------------------------------------------------*/
 void
-ShowDeckMap (Level deck)
+ShowDeckMap (void)
 {
   finepoint tmp;
   tmp.x=Me.pos.x;

--- a/src/sound.c
+++ b/src/sound.c
@@ -44,7 +44,7 @@
 // DO NOT CHANGE THE ORDER OF APPEARENCE IN THIS LIST unless you
 // also adjust the order of appearance in defs.h!
 
-char *SoundSampleFilenames[ALL_SOUNDS] = {
+const char *SoundSampleFilenames[ALL_SOUNDS] = {
    "ERRORSOUND_NILL.NOWAV",
    "Blast_Sound_0.wav",
    // "Collision_Sound_0.wav", // replaced by damage-dependent-sounds:  Collision_[Neutral|GotDamaged|DamagedEnemy]
@@ -85,7 +85,7 @@ char *SoundSampleFilenames[ALL_SOUNDS] = {
 Mix_Chunk *Loaded_WAV_Files[ALL_SOUNDS];
 #endif
 
-char *MusicFiles [NUM_COLORS] = {  // we have a background song per color now
+const char *MusicFiles [NUM_COLORS] = {  // we have a background song per color now
 #ifdef ANDROID
   "AnarchyMenu1.mod.ogg",                 // RED
   "starpaws.mod.ogg",                     // YELLOW
@@ -688,12 +688,11 @@ void
 FreeSounds ( void )
 {
 #ifdef HAVE_LIBSDL_MIXER
-  int i;
-  for (i = 0; i < sizeof(Loaded_WAV_Files)/sizeof(Loaded_WAV_Files[0]); i++) {
+  for (size_t i = 0; i < NUM_ELEM(Loaded_WAV_Files); i++) {
     if ( Loaded_WAV_Files[i] != NULL ) { Mix_FreeChunk ( Loaded_WAV_Files[i] ); }
   }
 
-  for ( i = 0; i < sizeof(MusicSongs)/sizeof(MusicSongs[0]); i ++ ) {
+  for ( size_t i = 0; i < NUM_ELEM(MusicSongs); i ++ ) {
     if ( MusicSongs[i] != NULL )  { Mix_FreeMusic ( MusicSongs[i] ); }
   }
 

--- a/src/struct.h
+++ b/src/struct.h
@@ -160,7 +160,7 @@ typedef struct
   float LastCrysoundTime;
   float LastTransferSoundTime;
   float TextVisibleTime;
-  char* TextToBeDisplayed;
+  const char* TextToBeDisplayed;
   gps Position_History_Ring_Buffer[ MAX_INFLU_POSITION_HISTORY ];
 }
 influence_t, *Influence_t;
@@ -180,7 +180,7 @@ typedef struct
   byte passable;		/* Zeit (counter), in der druid passable ist */
   float firewait;		/* gibt die Zeit bis zum naechsten Schuss an */
   float TextVisibleTime;
-  char* TextToBeDisplayed;
+  const char* TextToBeDisplayed;
   int NumberOfPeriodicSpecialStatements;
   char **PeriodicSpecialStatements;
 }

--- a/src/takeover.c
+++ b/src/takeover.c
@@ -124,7 +124,7 @@ int DisplayColumn[NUM_LINES] = {
 };
 
 
-SDL_Color to_bg_color = {130,130,130};
+SDL_Color to_bg_color = {.r = 130, .g = 130, .b = 130};
 
 playground_t ToPlayground;
 playground_t ActivationMap;
@@ -142,7 +142,7 @@ Takeover (int enemynum)
   int row;
   int FinishTakeover = FALSE;
   static int RejectEnergy = 0;	/* your energy if you're rejected */
-  char *message;
+  const char *message;
   SDL_Rect buf;
   Uint32 now;
 
@@ -658,7 +658,6 @@ void
 ShowPlayground (void)
 {
   int i, j;
-  int color, player;
   int block;
   int xoffs, yoffs;
   SDL_Rect dst;
@@ -750,25 +749,26 @@ ShowPlayground (void)
       }
 
   /* Show the capsules left for each player */
-  for (player = 0; player < 2; player++)
+  for (int player = 0; player < 2; player++)
     {
+      int drawcolor;
       if (player == YOU)
-	color = YourColor;
+	drawcolor = YourColor;
       else
-	color = OpponentColor;
+	drawcolor = OpponentColor;
 
-      Set_Rect (dst, xoffs + CurCapsuleStart[color].x,
-		yoffs + CurCapsuleStart[color].y + CapsuleCurRow[color] * TO_CapsuleRect.h,
+      Set_Rect (dst, xoffs + CurCapsuleStart[drawcolor].x,
+		yoffs + CurCapsuleStart[drawcolor].y + CapsuleCurRow[drawcolor] * TO_CapsuleRect.h,
 		0,0);
       if (NumCapsules[player])
-	SDL_BlitSurface (to_blocks, &CapsuleBlocks[color], ne_screen, &dst);
+	SDL_BlitSurface (to_blocks, &CapsuleBlocks[drawcolor], ne_screen, &dst);
 
 
       for (i = 0; i < NumCapsules[player]-1; i++)
 	{
-	  Set_Rect (dst, xoffs + LeftCapsulesStart[color].x,
-		    yoffs + LeftCapsulesStart[color].y + i*TO_CapsuleRect.h, 0, 0);
-	  SDL_BlitSurface (to_blocks, &CapsuleBlocks[color],
+	  Set_Rect (dst, xoffs + LeftCapsulesStart[drawcolor].x,
+		    yoffs + LeftCapsulesStart[drawcolor].y + i*TO_CapsuleRect.h, 0, 0);
+	  SDL_BlitSurface (to_blocks, &CapsuleBlocks[drawcolor],
 			   ne_screen, &dst);
 	} /* for capsules */
     } /* for player */
@@ -786,17 +786,17 @@ ShowPlayground (void)
 void
 ClearPlayground (void)
 {
-  int color, layer, row;
+  int layer, row;
 
-  for (color = GELB; color < TO_COLORS; color++)
+  for (int to_color = GELB; to_color < TO_COLORS; to_color++)
     for (layer = 0; layer < NUM_LAYERS; layer++)
       for (row = 0; row < NUM_LINES; row++)
 	{
-	  ActivationMap[color][layer][row] = INACTIVE;
+	  ActivationMap[to_color][layer][row] = INACTIVE;
 	  if (layer < TO_COLORS - 1)
-	    ToPlayground[color][layer][row] = KABEL;
+	    ToPlayground[to_color][layer][row] = KABEL;
 	  else
-	    ToPlayground[color][layer][row] = INACTIVE;
+	    ToPlayground[to_color][layer][row] = INACTIVE;
 	}
 
   for (row = 0; row < NUM_LINES; row++)
@@ -817,18 +817,17 @@ InventPlayground (void)
   int anElement;
   int newElement;
   int row, layer;
-  int color = GELB;
 
   /* first clear the playground: we depend on this !! */
   ClearPlayground ();
 
-  for (color = GELB; color < TO_COLORS; color++)
+  for (int to_color = GELB; to_color < TO_COLORS; to_color++)
     {
       for (layer = 1; layer < NUM_LAYERS - 1; layer++)
 	{
 	  for (row = 0; row < NUM_LINES; row++)
 	    {
-	      if (ToPlayground[color][layer][row] != KABEL)
+	      if (ToPlayground[to_color][layer][row] != KABEL)
 		continue;
 
 	      newElement = MyRandom (TO_ELEMENTS-1);
@@ -841,25 +840,25 @@ InventPlayground (void)
 	      switch (newElement)
 		{
 		case EL_KABEL:	/* has not to be set any more */
-		  anElement = ToPlayground[color][layer - 1][row];
+		  anElement = ToPlayground[to_color][layer - 1][row];
 		  if (BlockClass[anElement] == NON_CONNECTOR)
-		    ToPlayground[color][layer][row] = LEER;
+		    ToPlayground[to_color][layer][row] = LEER;
 		  break;
 
 		case EL_KABELENDE:
-		  anElement = ToPlayground[color][layer - 1][row];
+		  anElement = ToPlayground[to_color][layer - 1][row];
 		  if (BlockClass[anElement] == NON_CONNECTOR)
-		    ToPlayground[color][layer][row] = LEER;
+		    ToPlayground[to_color][layer][row] = LEER;
 		  else
-		    ToPlayground[color][layer][row] = KABELENDE;
+		    ToPlayground[to_color][layer][row] = KABELENDE;
 		  break;
 
 		case EL_VERSTAERKER:
-		  anElement = ToPlayground[color][layer - 1][row];
+		  anElement = ToPlayground[to_color][layer - 1][row];
 		  if (BlockClass[anElement] == NON_CONNECTOR)
-		    ToPlayground[color][layer][row] = LEER;
+		    ToPlayground[to_color][layer][row] = LEER;
 		  else
-		    ToPlayground[color][layer][row] = VERSTAERKER;
+		    ToPlayground[to_color][layer][row] = VERSTAERKER;
 		  break;
 
 		case EL_FARBTAUSCHER:
@@ -869,11 +868,11 @@ InventPlayground (void)
 		      continue;
 		    }
 
-		  anElement = ToPlayground[color][layer - 1][row];
+		  anElement = ToPlayground[to_color][layer - 1][row];
 		  if (BlockClass[anElement] == NON_CONNECTOR)
-		    ToPlayground[color][layer][row] = LEER;
+		    ToPlayground[to_color][layer][row] = LEER;
 		  else
-		    ToPlayground[color][layer][row] = FARBTAUSCHER;
+		    ToPlayground[to_color][layer][row] = FARBTAUSCHER;
 		  break;
 
 		case EL_VERZWEIGUNG:
@@ -884,7 +883,7 @@ InventPlayground (void)
 		      break;
 		    }
 
-		  anElement = ToPlayground[color][layer - 1][row + 1];
+		  anElement = ToPlayground[to_color][layer - 1][row + 1];
 		  if (BlockClass[anElement] == NON_CONNECTOR)
 		    {
 		      /* try again */
@@ -893,14 +892,14 @@ InventPlayground (void)
 		    }
 
 		  /* dont destroy verzweigungen in prev. layer */
-		  anElement = ToPlayground[color][layer - 1][row];
+		  anElement = ToPlayground[to_color][layer - 1][row];
 		  if (anElement == VERZWEIGUNG_O
 		      || anElement == VERZWEIGUNG_U)
 		    {
 		      row--;
 		      break;
 		    }
-		  anElement = ToPlayground[color][layer - 1][row + 2];
+		  anElement = ToPlayground[to_color][layer - 1][row + 2];
 		  if (anElement == VERZWEIGUNG_O
 		      || anElement == VERZWEIGUNG_U)
 		    {
@@ -909,18 +908,18 @@ InventPlayground (void)
 		    }
 
 		  /* cut off kabels in last layer, if any */
-		  anElement = ToPlayground[color][layer - 1][row];
+		  anElement = ToPlayground[to_color][layer - 1][row];
 		  if (BlockClass[anElement] == CONNECTOR)
-		    ToPlayground[color][layer - 1][row] = KABELENDE;
+		    ToPlayground[to_color][layer - 1][row] = KABELENDE;
 
-		  anElement = ToPlayground[color][layer - 1][row + 2];
+		  anElement = ToPlayground[to_color][layer - 1][row + 2];
 		  if (BlockClass[anElement] == CONNECTOR)
-		    ToPlayground[color][layer - 1][row + 2] = KABELENDE;
+		    ToPlayground[to_color][layer - 1][row + 2] = KABELENDE;
 
 		  /* set the verzweigung itself */
-		  ToPlayground[color][layer][row] = VERZWEIGUNG_O;
-		  ToPlayground[color][layer][row + 1] = VERZWEIGUNG_M;
-		  ToPlayground[color][layer][row + 2] = VERZWEIGUNG_U;
+		  ToPlayground[to_color][layer][row] = VERZWEIGUNG_O;
+		  ToPlayground[to_color][layer][row + 1] = VERZWEIGUNG_M;
+		  ToPlayground[to_color][layer][row + 2] = VERZWEIGUNG_U;
 
 		  row += 2;
 		  break;
@@ -933,14 +932,14 @@ InventPlayground (void)
 		      break;
 		    }
 
-		  anElement = ToPlayground[color][layer - 1][row];
+		  anElement = ToPlayground[to_color][layer - 1][row];
 		  if (BlockClass[anElement] == NON_CONNECTOR)
 		    {
 		      /* try again */
 		      row--;
 		      break;
 		    }
-		  anElement = ToPlayground[color][layer - 1][row + 2];
+		  anElement = ToPlayground[to_color][layer - 1][row + 2];
 		  if (BlockClass[anElement] == NON_CONNECTOR)
 		    {
 		      /* try again */
@@ -950,14 +949,14 @@ InventPlayground (void)
 
 
 		  /* cut off kabels in last layer, if any */
-		  anElement = ToPlayground[color][layer - 1][row + 1];
+		  anElement = ToPlayground[to_color][layer - 1][row + 1];
 		  if (BlockClass[anElement] == CONNECTOR)
-		    ToPlayground[color][layer - 1][row + 1] = KABELENDE;
+		    ToPlayground[to_color][layer - 1][row + 1] = KABELENDE;
 
 		  /* set the GATTER itself */
-		  ToPlayground[color][layer][row] = GATTER_O;
-		  ToPlayground[color][layer][row + 1] = GATTER_M;
-		  ToPlayground[color][layer][row + 2] = GATTER_U;
+		  ToPlayground[to_color][layer][row] = GATTER_O;
+		  ToPlayground[to_color][layer][row + 1] = GATTER_M;
+		  ToPlayground[to_color][layer][row + 2] = GATTER_U;
 
 		  row += 2;
 		  break;
@@ -973,7 +972,7 @@ InventPlayground (void)
 
 	}			/* for layer */
 
-    }				/* for color */
+    }				/* for to_color */
 
 }				/* InventPlayground */
 
@@ -986,10 +985,10 @@ InventPlayground (void)
 void
 ProcessPlayground (void)
 {
-  int color, layer, row;
+  int layer, row;
   int TurnActive = FALSE;
 
-  for (color = GELB; color < TO_COLORS; color++)
+  for (int to_color = GELB; to_color < TO_COLORS; to_color++)
     {
       for (layer = 1; layer < NUM_LAYERS; layer++)
 	{
@@ -997,33 +996,33 @@ ProcessPlayground (void)
 	    {
 	      if (layer == NUM_LAYERS - 1)
 		{
-		  if (IsActive (color, row))
-		    ActivationMap[color][layer][row] = ACTIVE1;
+		  if (IsActive (to_color, row))
+		    ActivationMap[to_color][layer][row] = ACTIVE1;
 		  else
-		    ActivationMap[color][layer][row] = INACTIVE;
+		    ActivationMap[to_color][layer][row] = INACTIVE;
 
 		  continue;
 		}		/* if last layer */
 
 	      TurnActive = FALSE;
 
-	      switch (ToPlayground[color][layer][row])
+	      switch (ToPlayground[to_color][layer][row])
 		{
 		case FARBTAUSCHER:
 		case VERZWEIGUNG_M:
 		case GATTER_O:
 		case GATTER_U:
 		case KABEL:
-		  if (ActivationMap[color][layer - 1][row] >= ACTIVE1)
+		  if (ActivationMap[to_color][layer - 1][row] >= ACTIVE1)
 		    TurnActive = TRUE;
 		  break;
 
 		case VERSTAERKER:
-		  if (ActivationMap[color][layer - 1][row] >= ACTIVE1)
+		  if (ActivationMap[to_color][layer - 1][row] >= ACTIVE1)
 		    TurnActive = TRUE;
 
 		  /* Verstaerker halten sich aber auch selbst aktiv !! */
-		  if (ActivationMap[color][layer][row] >= ACTIVE1)
+		  if (ActivationMap[to_color][layer][row] >= ACTIVE1)
 		    TurnActive = TRUE;
 
 		  break;
@@ -1032,18 +1031,18 @@ ProcessPlayground (void)
 		  break;
 
 		case VERZWEIGUNG_O:
-		  if (ActivationMap[color][layer][row + 1] >= ACTIVE1)
+		  if (ActivationMap[to_color][layer][row + 1] >= ACTIVE1)
 		    TurnActive = TRUE;
 		  break;
 
 		case VERZWEIGUNG_U:
-		  if (ActivationMap[color][layer][row - 1] >= ACTIVE1)
+		  if (ActivationMap[to_color][layer][row - 1] >= ACTIVE1)
 		    TurnActive = TRUE;
 		  break;
 
 		case GATTER_M:
-		  if ((ActivationMap[color][layer][row - 1] >= ACTIVE1)
-		      && (ActivationMap[color][layer][row + 1] >= ACTIVE1))
+		  if ((ActivationMap[to_color][layer][row - 1] >= ACTIVE1)
+		      && (ActivationMap[to_color][layer][row + 1] >= ACTIVE1))
 		    TurnActive = TRUE;
 
 		  break;
@@ -1054,19 +1053,19 @@ ProcessPlayground (void)
 
 	      if (TurnActive)
 		{
-		  if (ActivationMap[color][layer][row] == INACTIVE)
-		    ActivationMap[color][layer][row] = ACTIVE1;
+		  if (ActivationMap[to_color][layer][row] == INACTIVE)
+		    ActivationMap[to_color][layer][row] = ACTIVE1;
 		  TurnActive = FALSE;
 		}
 	      else
-		ActivationMap[color][layer][row] = INACTIVE;
+		ActivationMap[to_color][layer][row] = INACTIVE;
 
 
 	    }			/* for row */
 
 	}			/* for layer */
 
-    }				/* for color */
+    }				/* for to_color */
 
   return;
 }				/* ProcessPlayground */
@@ -1178,20 +1177,17 @@ ProcessDisplayColumn (void)
 void
 ProcessCapsules (void)
 {
-  int row;
-  int color;
-
-  for (color = GELB; color <= VIOLETT; color++)
-    for (row = 0; row < NUM_LINES; row++)
+  for (int to_color = GELB; to_color <= VIOLETT; to_color++)
+    for (int row = 0; row < NUM_LINES; row++)
       {
-	if (CapsuleCountdown[color][0][row] > 0)
-	  CapsuleCountdown[color][0][row]--;
+	if (CapsuleCountdown[to_color][0][row] > 0)
+	  CapsuleCountdown[to_color][0][row]--;
 
-	if (CapsuleCountdown[color][0][row] == 0)
+	if (CapsuleCountdown[to_color][0][row] == 0)
 	  {
-	    CapsuleCountdown[color][0][row] = -1;
-	    ActivationMap[color][0][row] = INACTIVE;
-	    ToPlayground[color][0][row] = KABEL;
+	    CapsuleCountdown[to_color][0][row] = -1;
+	    ActivationMap[to_color][0][row] = INACTIVE;
+	    ToPlayground[to_color][0][row] = KABEL;
 	  }
 
       } /* for row */
@@ -1200,19 +1196,19 @@ ProcessCapsules (void)
 
 
 /*@Function============================================================
-@Desc: IsInactive(color, row): tells, wether a Column-connection
+@Desc: IsInactive(to_color, row): tells, wether a Column-connection
 						is active or not
 
 @Ret: TRUE/FALSE
 @Int:
 * $Function----------------------------------------------------------*/
 int
-IsActive (int color, int row)
+IsActive (int to_color, int row)
 {
   int CLayer = 3;		/* the connective Layer */
-  int TestElement = ToPlayground[color][CLayer - 1][row];
+  int TestElement = ToPlayground[to_color][CLayer - 1][row];
 
-  if ((ActivationMap[color][CLayer-1][row] >= ACTIVE1) &&
+  if ((ActivationMap[to_color][CLayer-1][row] >= ACTIVE1) &&
       (BlockClass[TestElement] == CONNECTOR))
     return TRUE;
   else
@@ -1229,16 +1225,16 @@ IsActive (int color, int row)
 void
 AnimateCurrents (void)
 {
-  int color, layer, row;
+  int layer, row;
 
-  for (color = GELB; color <= VIOLETT; color ++)
+  for (int to_color = GELB; to_color <= VIOLETT; to_color ++)
     for (layer = 0; layer < NUM_LAYERS; layer ++)
       for (row = 0; row < NUM_LINES; row ++)
-	if (ActivationMap[color][layer][row] >= ACTIVE1)
+	if (ActivationMap[to_color][layer][row] >= ACTIVE1)
 	  {
-	    ActivationMap[color][layer][row] ++;
-	    if (ActivationMap[color][layer][row] == NUM_PHASES)
-	      ActivationMap[color][layer][row] = ACTIVE1;
+	    ActivationMap[to_color][layer][row] ++;
+	    if (ActivationMap[to_color][layer][row] == NUM_PHASES)
+	      ActivationMap[to_color][layer][row] = ACTIVE1;
 	  }
 
   return;

--- a/src/text.c
+++ b/src/text.c
@@ -191,7 +191,7 @@ AddInfluBurntText( void )
  *           1  if user pressed fire
  *-----------------------------------------------------------------*/
 int
-ScrollText (char *Text, SDL_Rect *rect, int SecondsMinimumDuration )
+ScrollText (char *Text, SDL_Rect *rect)
 {
   int Number_Of_Line_Feeds = 0;		/* Anzahl der Textzeilen */
   char *textpt;			/* bewegl. Textpointer */
@@ -645,11 +645,10 @@ putchar_SDL (SDL_Surface *Surface, int x, int y, int c)
  *
  *-----------------------------------------------------------------*/
 void
-printf_SDL (SDL_Surface *screen, int x, int y, char *fmt, ...)
+printf_SDL (SDL_Surface *screen, int x, int y, const char *fmt, ...)
 {
   va_list args;
-  int i, h, textlen;
-
+  int h, textlen;
 
   va_start (args, fmt);
 
@@ -661,7 +660,7 @@ printf_SDL (SDL_Surface *screen, int x, int y, char *fmt, ...)
 
   vsprintf (TextBuffer, fmt, args);
   textlen = 0;
-  for (i=0; i < strlen(TextBuffer); i++)
+  for (size_t i = 0; i < strlen(TextBuffer); i++)
     textlen += CharWidth (GetCurrentFont(), TextBuffer[i]);
 
   PutString (screen, x, y, TextBuffer);

--- a/src/vars.h
+++ b/src/vars.h
@@ -65,10 +65,16 @@ SDL_Rect ProgressText_Rect = {213, 390, 157, 30};
 
 int ShipEmptyCounter = 0;	/* counter to Message: you have won(this ship */
 
-influence_t Me = {
-  DRUID001, TRANSFERMODE, {0, 0}, {120, 48}, 100, 100, 0, 0, 0, 0, 0, 0, NULL };
+influence_t Me =
+  {
+    .type = DRUID001,
+    .status = TRANSFERMODE,
+    .pos = {120, 48},
+    .health = 100,
+    .energy = 100
+  };
 
-char *InfluenceModeNames[] = {
+const char *InfluenceModeNames[] = {
   "Mobile",
   "Transfer",
   "Weapon",
@@ -90,7 +96,7 @@ char *InfluenceModeNames[] = {
 };
 
 
-char *Classname[] = {
+const char *Classname[] = {
   "Influence device",
   "Disposal robot",
   "Servant robot",
@@ -104,7 +110,7 @@ char *Classname[] = {
   NULL
 };
 
-char *Classes[] = {
+const char *Classes[] = {
   "influence",
   "disposal",
   "servant",
@@ -118,21 +124,21 @@ char *Classes[] = {
   "error"
 };
 
-char *Shipnames[ALLSHIPS] = {
+const char *Shipnames[ALLSHIPS] = {
   "Paradroid",
   "Metahawk",
   "Graftgold",
   NULL
 };
 
-char *Alertcolor[AL_LAST] = {
+const char *Alertcolor[AL_LAST] = {
   "green",
   "yellow",
   "amber",
   "red"
 };
 
-char *Drivenames[] = {
+const char *Drivenames[] = {
   "none",
   "tracks",
   "anti-grav",
@@ -142,7 +148,7 @@ char *Drivenames[] = {
   "error"
 };
 
-char *Sensornames[] = {
+const char *Sensornames[] = {
   " - ",
   "spectral",
   "infra-red",
@@ -152,14 +158,14 @@ char *Sensornames[] = {
   "error"
 };
 
-char *Brainnames[] = {
+const char *Brainnames[] = {
   "none",
   "neutronic",
   "primode",
   "error"
 };
 
-char *Weaponnames[] = {      // Bullet-names:
+const char *Weaponnames[] = {      // Bullet-names:
   "none",                    // pulse
   "lasers",                  // single
   "lasers",                  // Military

--- a/src/view.c
+++ b/src/view.c
@@ -44,24 +44,13 @@
 #include "map.h"
 #include "proto.h"
 
-SDL_Color Black = {0, 0, 0};
-SDL_Color Flash_Light = {11, 11, 11};
-SDL_Color Flash_Dark  = {230, 230, 230};
+SDL_Color Black = {.r = 0, .g = 0, .b = 0};
+SDL_Color Flash_Light = {.r = 11, .g = 11, .b = 11};
+SDL_Color Flash_Dark  = {.r = 230, .g = 230, .b = 230};
 
 #define BLINK_LEN 1.0   // length of one blink cycle at low energy (in s)
 
-/*----------------------------------------------------------------------
- * Map2ScreenXY (): translate a map-pos (x,y) to screen-coords (X,Y)
- *                  using influ-position Me.pos
- *
- *----------------------------------------------------------------------*/
-void
-Map2ScreenXY (finepoint mappos, point *screenpos)
-{
-
-
-
-}// Map2ScreenXY()
+// local prototypes
 
 /*
 -----------------------------------------------------------------
@@ -93,7 +82,7 @@ Assemble_Combat_Picture (int mask)
   static int FPS_Displayed=1;
   SDL_Rect TargetRectangle;
   SDL_Rect TxtRect;
-  finepoint pos, vect;
+  finepoint pos;
   float len;
   grob_point upleft, downright;
 
@@ -129,15 +118,16 @@ Assemble_Combat_Picture (int mask)
 	    {
 	      pos.x = col;
 	      pos.y = line;
-	      vect.x = Me.pos.x - pos.x;
-	      vect.y = Me.pos.y - pos.y;
-	      len = sqrt( vect.x * vect.x + vect.y * vect.y) + 0.01;
-	      vect.x /= len;
-	      vect.y /= len;
+              finepoint offs;
+	      offs.x = Me.pos.x - pos.x;
+	      offs.y = Me.pos.y - pos.y;
+	      len = sqrt( offs.x * offs.x + offs.y * offs.y) + 0.01;
+	      offs.x /= len;
+	      offs.y /= len;
 	      if (len > 0.5)
 		{
-		  pos.x += vect.x;
-		  pos.y += vect.y;
+		  pos.x += offs.x;
+		  pos.y += offs.y;
 		}
 	      if ( !IsVisible (&pos) )
 		continue;
@@ -603,13 +593,13 @@ PutBlast (int BlastNummer)
 @Ret: none
 * $Function----------------------------------------------------------*/
 void
-SetUserfenster (int color)
+SetUserfenster (int fillcolor)
 {
   SDL_Rect tmp;
 
   Set_Rect (tmp, User_Rect.x, User_Rect.y, User_Rect.w, User_Rect.h);
 
-  SDL_FillRect( ne_screen , &tmp, color );
+  SDL_FillRect( ne_screen , &tmp, fillcolor );
 
   return;
 }				/* SetUserFenster() */
@@ -619,14 +609,14 @@ SetUserfenster (int color)
  *
  *-----------------------------------------------------------------*/
 void
-Fill_Rect (SDL_Rect rect, SDL_Color color)
+Fill_Rect (SDL_Rect rect, SDL_Color fillcolor)
 {
   Uint32 pixcolor;
   SDL_Rect tmp;
 
   Copy_Rect (rect, tmp);
 
-  pixcolor = SDL_MapRGB (ne_screen->format, color.r, color.g, color.b);
+  pixcolor = SDL_MapRGB (ne_screen->format, fillcolor.r, fillcolor.g, fillcolor.b);
 
   SDL_FillRect (ne_screen, &tmp, pixcolor);
 
@@ -692,8 +682,8 @@ DisplayBanner (const char* left, const char* right,  int flags )
   memset (left_box,  ' ', LEFT_TEXT_LEN);  /* pad with spaces */
   memset (right_box, ' ', RIGHT_TEXT_LEN);
 
-  strncpy (left_box,  left, left_len);  /* this drops terminating \0 ! */
-  strncpy (right_box, right, left_len);  /* this drops terminating \0 ! */
+  memcpy (left_box,  left, left_len * sizeof(left[0]));  /* this drops terminating \0 ! */
+  memcpy (right_box, right, left_len * sizeof(right[0]));  /* this drops terminating \0 ! */
 
   left_box [LEFT_TEXT_LEN]  = '\0';     /* that's right, we want padding! */
   right_box[RIGHT_TEXT_LEN] = '\0';


### PR DESCRIPTION
- Android build fix for old devices (eg Android 7, 8) entails building
  an older libpng version 1.6.25, which does not depend on newer zlib (>1.2.8)
  than found on those older devices, later versions using
  'inflateValidate' in newer zlibs crash on those older devices
- fix: check out tag 'v1.6.25' in libpng, use suitable 'Android.mk' file
- fixes issue https://github.com/ReinhardPrix/FreedroidClassic/issues/40

- also fix end-game crash due to trying to play mikmod file 'commando.mod' instead of converted .ogg file
