### PR TITLE
Fix clang build warnings, relax default build, expand CI

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -7,8 +7,23 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  ubuntu-build:
+    name: ubuntu/${{ matrix.name }}
+    runs-on: ${{ matrix.runs_on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: gcc
+            runs_on: ubuntu-24.04
+            cc: gcc
+            make_target: all
+          - name: clang-strict
+            runs_on: ubuntu-latest
+            cc: clang
+            make_target: strict
+    env:
+      CC: ${{ matrix.cc }}
 
     steps:
     - uses: actions/checkout@v4
@@ -32,4 +47,51 @@ jobs:
       run: ./configure
 
     - name: Build
-      run: make -j"$(nproc)"
+      run: make -j"$(nproc)" ${{ matrix.make_target }}
+
+  arch-build:
+    name: arch/${{ matrix.name }}
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: gcc
+            cc: gcc
+            make_target: all
+          - name: clang-strict
+            cc: clang
+            make_target: strict
+    env:
+      CC: ${{ matrix.cc }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install build dependencies
+      run: |
+        pacman -Syu --noconfirm --needed \
+          autoconf \
+          automake \
+          gcc \
+          clang \
+          libjpeg-turbo \
+          libpng \
+          libtool \
+          libvorbis \
+          make \
+          pkgconf \
+          sdl2 \
+          sdl2_image \
+          sdl2_mixer
+
+    - name: Bootstrap autotools
+      run: ./00boot
+
+    - name: Configure
+      run: ./configure
+
+    - name: Build
+      run: make -j"$(nproc)" ${{ matrix.make_target }}

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,6 +4,11 @@ man_MANS = freedroid.6
 
 EXTRA_DIST = $(man_MANS) mac-osx
 
+.PHONY: strict
+
+strict:
+	$(MAKE) WERROR_CFLAGS=-Werror all
+
 ## Win32 specific stuff follows here
 
 win_txts = COPYING AUTHORS README Releasetext freedroid-man
@@ -34,4 +39,3 @@ android-data:
 	mkdir -p AndroidData
 	zip -r AndroidData/data-1.2.2.zip graphics/ sound/*.wav sound/*.ogg map/
 	cp graphics/title.jpg AndroidData/logo.jpg
-

--- a/src/BFont.c
+++ b/src/BFont.c
@@ -321,7 +321,7 @@ TextWidthFont (BFont_Info * Font, const char *text)
 int
 count (const char *text)
 {
-  char *p = NULL;
+  const char *p = NULL;
   int pos = -1;
   int i = 0;
   /* Calculate the space occupied by the text without spaces */
@@ -349,7 +349,7 @@ JustifiedPutStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
   int dif;
 
   char *strtmp;
-  char *p;
+  const char *p;
   int pos = -1;
   int xpos = 0;
 
@@ -642,7 +642,10 @@ PutPixel (SDL_Surface * surface, int x, int y, Uint32 pixel)
       break;
 
     case 2:
-      *(Uint16 *) p = pixel;
+      {
+        Uint16 pixel16 = (Uint16) pixel;
+        memcpy (p, &pixel16, sizeof (pixel16));
+      }
       break;
 
     case 3:
@@ -661,7 +664,7 @@ PutPixel (SDL_Surface * surface, int x, int y, Uint32 pixel)
       break;
 
     case 4:
-      *(Uint32 *) p = pixel;
+      memcpy (p, &pixel, sizeof (pixel));
       break;
     }
 }

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 ## Process this file with automake to produce Makefile.in
 
-AM_CFLAGS = -Wall -W -Werror -Wunused -Wmissing-prototypes -Wstrict-prototypes -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -fno-common -Wnested-externs -Wno-format-zero-length -fno-strict-aliasing -Wno-unused-result -Wno-unknown-pragmas -Wno-misleading-indentation
+AM_CFLAGS = -Wall -W $(WERROR_CFLAGS) -Wunused -Wmissing-prototypes -Wstrict-prototypes -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -fno-common -Wnested-externs -Wno-format-zero-length -fno-strict-aliasing -Wno-unused-result -Wno-unknown-pragmas -Wno-misleading-indentation
 
 bin_PROGRAMS = freedroid
 
@@ -58,3 +58,8 @@ freedroidDebug_CPPFLAGS = $(freedroid_CPPFLAGS)
 WINDRES = i586-mingw32msvc-windres
 freedroid.coff: freedroid.rc ../graphics/paraicon.ico
 	$(WINDRES) -i freedroid.rc -o freedroid.coff -O COFF
+
+.PHONY: strict
+
+strict:
+	$(MAKE) WERROR_CFLAGS=-Werror all

--- a/src/bullet.c
+++ b/src/bullet.c
@@ -278,7 +278,6 @@ CheckBulletCollisions (int num)
   int levelnum = CurLevel->levelnum;
   float xdist, ydist;
   Bullet CurBullet = &AllBullets[num];
-  static int FBTZaehler = 0;
   finepoint step;
   int num_check_steps, stepnum;
   int i;
@@ -408,7 +407,6 @@ CheckBulletCollisions (int num)
 
 		  if (!CurBullet->mine)
 		    {
-		      FBTZaehler++;
 		    }
 		  CurBullet->type = OUT;
 		  CurBullet->mine = FALSE;

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1054,7 +1054,11 @@ getpixel(SDL_Surface *surface, int x, int y)
       return *p;
 
     case 2:
-      return *(Uint16 *)p;
+      {
+        Uint16 pixel16;
+        memcpy (&pixel16, p, sizeof (pixel16));
+        return pixel16;
+      }
 
     case 3:
       if(SDL_BYTEORDER == SDL_BIG_ENDIAN)
@@ -1063,7 +1067,11 @@ getpixel(SDL_Surface *surface, int x, int y)
 	return p[0] | p[1] << 8 | p[2] << 16;
 
     case 4:
-      return *(Uint32 *)p;
+      {
+        Uint32 pixel32;
+        memcpy (&pixel32, p, sizeof (pixel32));
+        return pixel32;
+      }
 
     default:
       return 0;       /* shouldn't happen, but avoids warnings */
@@ -1092,7 +1100,10 @@ void putpixel(SDL_Surface *surface, int x, int y, Uint32 pixel)
         break;
 
     case 2:
-        *(Uint16 *)p = pixel;
+        {
+          Uint16 pixel16 = (Uint16) pixel;
+          memcpy (p, &pixel16, sizeof (pixel16));
+        }
         break;
 
     case 3:
@@ -1108,7 +1119,7 @@ void putpixel(SDL_Surface *surface, int x, int y, Uint32 pixel)
         break;
 
     case 4:
-        *(Uint32 *)p = pixel;
+        memcpy (p, &pixel, sizeof (pixel));
         break;
     }
 } // void putpixel(...)

--- a/src/init.c
+++ b/src/init.c
@@ -237,7 +237,7 @@ void
 Get_Robot_Data ( void* DataPointer )
 {
   int RobotIndex = 0;
-  char *RobotPointer;
+  const char *RobotPointer;
 
   float maxspeed_calibrator;
   float acceleration_calibrator;
@@ -590,7 +590,7 @@ InitNewMission ( const char *MissionName )
   char *fpath;
   int i;
   char *MainMissionPointer;
-  char *BriefingSectionPointer;
+  const char *BriefingSectionPointer;
   char *StartPointPointer;
   char Buffer[500];
   int NumberOfStartPoints=0;
@@ -959,7 +959,7 @@ Title ( const char *MissionBriefingPointer )
 {
   const char* NextSubsectionStartPointer;
   char* PreparedBriefingText = NULL;
-  char* TerminationPointer;
+  const char* TerminationPointer;
   char Buffer[500];
   int ThisTextLength;
   SDL_Rect rect;

--- a/src/map.c
+++ b/src/map.c
@@ -967,7 +967,7 @@ GetLiftConnections (char *filename)
 {
   char *fpath;
   char *Data;
-  char *EntryPointer;
+  const char *EntryPointer;
   int i;
   int Label;
   int DeckIndex;
@@ -1170,7 +1170,7 @@ GetThisLevelsDroids( const char* SectionPointer )
 {
   int OurLevelNumber;
   const char* SearchPointer;
-  char* EndOfThisLevelData;
+  const char* EndOfThisLevelData;
   int MaxRand;
   int MinRand;
   int RealNumberOfRandomDroids;
@@ -1189,7 +1189,6 @@ GetThisLevelsDroids( const char* SectionPointer )
   // printf("\nReceived another levels droid section for decoding. It reads: %s " , SectionPointer );
 
   EndOfThisLevelData = LocateStringInData ( SectionPointer , DROIDS_LEVEL_END_INDICATION_STRING );
-  EndOfThisLevelData[0]=0;
 
   // Now we read in the level number for this level
   ReadValueFromString (SectionPointer, DROIDS_LEVEL_INDICATION_STRING, "%d", &OurLevelNumber);
@@ -1202,7 +1201,9 @@ GetThisLevelsDroids( const char* SectionPointer )
 
   DifferentRandomTypes=0;
   SearchPointer = SectionPointer;
-  while ( ( SearchPointer = strstr ( SearchPointer , ALLOWED_TYPE_INDICATION_STRING)) != NULL)
+  while ( SearchPointer < EndOfThisLevelData &&
+	  ( SearchPointer = strstr ( SearchPointer , ALLOWED_TYPE_INDICATION_STRING)) != NULL &&
+	  SearchPointer < EndOfThisLevelData)
     {
       SearchPointer += strlen ( ALLOWED_TYPE_INDICATION_STRING );
       strncpy( TypeIndicationString , SearchPointer , 3 ); // Every type is 3 characters long

--- a/src/misc.c
+++ b/src/misc.c
@@ -340,8 +340,8 @@ The original source string specified should in no way be modified.
 char*
 ReadAndMallocStringFromData ( const char* SearchString , const char* StartIndicationString , const char* EndIndicationString )
 {
-  char* SearchPointer;
-  char* EndOfStringPointer;
+  const char* SearchPointer;
+  const char* EndOfStringPointer;
   char* ReturnString = NULL;
   int StringLength;
 
@@ -570,10 +570,10 @@ The return value is a pointer to the first instance where the substring
 we are searching is found in the main text.
 ----------------------------------------------------------------------
 */
-char*
+const char*
 LocateStringInData ( const char* SearchBeginPointer, const char* SearchTextPointer )
 {
-  char* temp;
+  const char* temp;
 
   if ( ( temp = strstr ( SearchBeginPointer , SearchTextPointer ) ) == NULL)
     {
@@ -619,7 +619,7 @@ not resolve.... Sorry, if that interrupts a major game of yours.....\n\
 void
 ReadValueFromString (const char* data, const char* label, const char* FormatString, void* dst)
 {
-  char *pos;
+  const char *pos;
 
   // Now we locate the label in data and position pointer right after the label
   pos = LocateStringInData (data, label); // ..will Terminate itself if not found...

--- a/src/proto.h
+++ b/src/proto.h
@@ -272,7 +272,7 @@ EXTERN char* ReadAndMallocStringFromData ( const char* SearchString , const char
 EXTERN int CountStringOccurences ( const char* SearchString , const char* TargetString ) ;
 EXTERN void ReadValueFromString(const char* data, const char* label, const char* FormatString, void* dst);
 EXTERN char* ReadAndMallocAndTerminateFile( const char* filename , const char* File_End_String ) ;
-EXTERN char* LocateStringInData ( const char* SearchBeginPointer, const char* SearchTextPointer ) ;
+EXTERN const char* LocateStringInData ( const char* SearchBeginPointer, const char* SearchTextPointer ) ;
 EXTERN char* find_file (const char *fname, const char *subdir, int use_theme, int critical);
 EXTERN void CheckForTriggeredEvents ( void );
 EXTERN void Pause (void);

--- a/src/text.c
+++ b/src/text.c
@@ -193,8 +193,6 @@ AddInfluBurntText( void )
 int
 ScrollText (char *Text, SDL_Rect *rect)
 {
-  int Number_Of_Line_Feeds = 0;		/* Anzahl der Textzeilen */
-  char *textpt;			/* bewegl. Textpointer */
   float InsertLine = 1.0*rect->y;
   int speed = 30;   // in pixel / sec
   int maxspeed = 150;
@@ -206,12 +204,6 @@ ScrollText (char *Text, SDL_Rect *rect)
   Background = SDL_ConvertSurface (ne_screen, ne_screen->format, 0);
 
   // first_tick = SDL_GetTicks ();
-
-  // count the number of lines in the text
-  textpt = Text;
-  while (*textpt++)
-    if (*textpt == '\n')
-      Number_Of_Line_Feeds++;
 
   wait_for_all_keys_released();
   while (1)


### PR DESCRIPTION
- should fix clang warnings (tested on clang-19 only @ Debian-trixie)
- relax default 'make' to not use '-Werror', only with special build target 'strict'
- expand CI tests to use gcc&clang on both ubuntu-latest and arch Linux

- fixes #45 