### PR TITLE
Add internal memleak tracker

### DIFF
--- a/src/BFont.c
+++ b/src/BFont.c
@@ -115,7 +115,7 @@ LoadFont (char *filename, float scale)
 	  else
 	    {
 	      /* free memory allocated for the BFont_Info structure */
-	      free (Font);
+	      MyFree (Font);
 	      Font = NULL;
 	    }
 	}
@@ -129,7 +129,7 @@ void
 FreeFont (BFont_Info * Font)
 {
   SDL_FreeSurface (Font->Surface);
-  free (Font);
+  MyFree (Font);
 }
 
 BFont_Info *
@@ -145,7 +145,7 @@ SetFontColor (BFont_Info * Font, Uint8 r, Uint8 g, Uint8 b)
   Uint8 new_r, new_g, new_b;
   Uint32 color_key;
 
-  newfont = (BFont_Info *) malloc (sizeof (BFont_Info));
+  newfont = (BFont_Info *) MyMalloc (sizeof (BFont_Info));
   if (newfont != NULL)
     {
 
@@ -378,7 +378,7 @@ JustifiedPutStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
 	      p = strstr (&text[pos + 1], " ");
 	      strtmp = NULL;
 	      strtmp =
-		(char *) calloc ((p - &text[pos + 1]) + 1, sizeof (char));
+		(char *) MyCalloc ((p - &text[pos + 1]) + 1, sizeof (char));
 	      if (strtmp != NULL)
 		{
 		  strncpy (strtmp, &text[pos + 1], (p - &text[pos + 1]));
@@ -394,19 +394,19 @@ JustifiedPutStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
 		    }
 		  pos = p - text;
 		  spaces--;
-		  free (strtmp);
+		  MyFree (strtmp);
 		}
 	    }
 	  strtmp = NULL;
           size_t len = strlen (&text[pos + 1]) + 1;
 	  strtmp =
-	    (char *) calloc (len, sizeof (char));
+	    (char *) MyCalloc (len, sizeof (char));
 
 	  if (strtmp != NULL)
 	    {
 	      memcpy (strtmp, &text[pos + 1], len);
 	      PutStringFont (Surface, Font, xpos, y, strtmp);
-	      free (strtmp);
+	      MyFree (strtmp);
 	    }
 	}
     }
@@ -468,7 +468,7 @@ PrintString (SDL_Surface * Surface, int x, int y, const char *fmt, ...)
 
       PutStringFont (Surface, CurrentFont, x, y, temp);
 
-      free (temp);
+      MyFree (temp);
     }
   va_end (args);
 }
@@ -485,7 +485,7 @@ PrintStringFont (SDL_Surface * Surface, BFont_Info * Font, int x, int y,
     {
       vsprintf (temp, fmt, args);
       PutStringFont (Surface, Font, x, y, temp);
-      free (temp);
+      MyFree (temp);
     }
   va_end (args);
 }
@@ -501,7 +501,7 @@ CenteredPrintString (SDL_Surface * Surface, int y, const char *fmt, ...)
     {
       vsprintf (temp, fmt, args);
       CenteredPutString (Surface, y, temp);
-      free (temp);
+      MyFree (temp);
     }
   va_end (args);
 }
@@ -518,7 +518,7 @@ CenteredPrintStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
     {
       vsprintf (temp, fmt, args);
       CenteredPutStringFont (Surface, Font, y, temp);
-      free (temp);
+      MyFree (temp);
     }
   va_end (args);
 
@@ -535,7 +535,7 @@ RightPrintString (SDL_Surface * Surface, int y, const char *fmt, ...)
     {
       vsprintf (temp, fmt, args);
       RightPutString (Surface, y, temp);
-      free (temp);
+      MyFree (temp);
     }
   va_end (args);
 }
@@ -552,7 +552,7 @@ RightPrintStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
     {
       vsprintf (temp, fmt, args);
       RightPutStringFont (Surface, Font, y, temp);
-      free (temp);
+      MyFree (temp);
     }
   va_end (args);
 }
@@ -568,7 +568,7 @@ LeftPrintString (SDL_Surface * Surface, int y, const char *fmt, ...)
     {
       vsprintf (temp, fmt, args);
       LeftPutString (Surface, y, temp);
-      free (temp);
+      MyFree (temp);
     }
   va_end (args);
 }
@@ -585,7 +585,7 @@ LeftPrintStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
     {
       vsprintf (temp, fmt, args);
       LeftPutStringFont (Surface, Font, y, temp);
-      free (temp);
+      MyFree (temp);
     }
   va_end (args);
 }
@@ -601,7 +601,7 @@ JustifiedPrintString (SDL_Surface * Surface, int y, const char *fmt, ...)
     {
       vsprintf (temp, fmt, args);
       JustifiedPutString (Surface, y, temp);
-      free (temp);
+      MyFree (temp);
     }
   va_end (args);
 }
@@ -618,7 +618,7 @@ JustifiedPrintStringFont (SDL_Surface * Surface, BFont_Info * Font, int y,
     {
       vsprintf (temp, fmt, args);
       JustifiedPutStringFont (Surface, Font, y, temp);
-      free (temp);
+      MyFree (temp);
     }
   va_end (args);
 }

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,6 +20,7 @@ freedroid_SOURCES = \
 		config.h \
 		defs.h \
 		enemy.c \
+		fd_memory.c \
 		global.h \
 		graphics.c \
 		highscore.c \

--- a/src/fd_memory.c
+++ b/src/fd_memory.c
@@ -1,0 +1,198 @@
+/*
+ * Internal allocation tracker inspired by LALSuite's memory-debugging API.
+ * Adapted for Freedroid to report project-owned leaks with allocation sites.
+ *
+ * Original idea and API style derived from LALSuite, which is also GPL-licensed.
+ */
+
+#define _fd_memory_c
+
+#include "system.h"
+
+#include "defs.h"
+#include "proto.h"
+
+typedef struct memory_block {
+  void *ptr;
+  size_t size;
+  const char *file;
+  int line;
+  struct memory_block *next;
+} memory_block;
+
+static memory_block *live_blocks = NULL;
+static size_t live_bytes = 0;
+static size_t live_count = 0;
+static size_t peak_bytes = 0;
+
+static void
+MemoryTrackerFatal (const char *func, size_t amount)
+{
+  fprintf (stderr, "Freedroid: %s(%zu) did not succeed!\n", func, amount);
+  exit (ERR);
+}
+
+static memory_block **
+FindTrackedBlock (void *ptr)
+{
+  memory_block **block = &live_blocks;
+
+  while (*block != NULL)
+    {
+      if ((*block)->ptr == ptr)
+        return block;
+      block = &((*block)->next);
+    }
+
+  return NULL;
+}
+
+static void *
+TrackBlock (void *ptr, size_t size, const char *file, int line)
+{
+  memory_block *block;
+
+  if (ptr == NULL)
+    return NULL;
+
+  block = malloc (sizeof (*block));
+  if (block == NULL)
+    {
+      free (ptr);
+      MemoryTrackerFatal ("memory tracker malloc", sizeof (*block));
+    }
+
+  block->ptr = ptr;
+  block->size = size;
+  block->file = file;
+  block->line = line;
+  block->next = live_blocks;
+  live_blocks = block;
+
+  live_count++;
+  live_bytes += size;
+  if (live_bytes > peak_bytes)
+    peak_bytes = live_bytes;
+
+  return ptr;
+}
+
+void *
+MyMallocLong (long amount, const char *file, int line)
+{
+  size_t size;
+  void *ptr;
+
+  if (amount <= 0)
+    amount = 1;
+
+  size = (size_t) amount;
+  ptr = calloc (1, size);
+  if (ptr == NULL)
+    MemoryTrackerFatal ("MyMalloc", size);
+
+  return TrackBlock (ptr, size, file, line);
+}
+
+void *
+MyCallocLong (size_t count, size_t size, const char *file, int line)
+{
+  void *ptr;
+  size_t total;
+
+  if (count == 0)
+    count = 1;
+  if (size == 0)
+    size = 1;
+
+  total = count * size;
+  ptr = calloc (count, size);
+  if (ptr == NULL)
+    MemoryTrackerFatal ("MyCalloc", total);
+
+  return TrackBlock (ptr, total, file, line);
+}
+
+void *
+MyReallocLong (void *ptr, size_t size, const char *file, int line)
+{
+  memory_block **block;
+  void *new_ptr;
+
+  if (ptr == NULL)
+    return MyCallocLong (1, size, file, line);
+
+  if (size == 0)
+    size = 1;
+
+  block = FindTrackedBlock (ptr);
+  new_ptr = realloc (ptr, size);
+  if (new_ptr == NULL)
+    MemoryTrackerFatal ("MyRealloc", size);
+
+  if (block == NULL)
+    return TrackBlock (new_ptr, size, file, line);
+
+  live_bytes -= (*block)->size;
+  (*block)->ptr = new_ptr;
+  (*block)->size = size;
+  (*block)->file = file;
+  (*block)->line = line;
+  live_bytes += size;
+  if (live_bytes > peak_bytes)
+    peak_bytes = live_bytes;
+
+  return new_ptr;
+}
+
+void
+MyFreeLong (void *ptr, const char *file, int line)
+{
+  memory_block **block;
+
+  (void) file;
+  (void) line;
+
+  if (ptr == NULL)
+    return;
+
+  block = FindTrackedBlock (ptr);
+  if (block != NULL)
+    {
+      memory_block *dead_block = *block;
+      *block = dead_block->next;
+      live_count--;
+      live_bytes -= dead_block->size;
+      free (dead_block);
+    }
+
+  free (ptr);
+}
+
+void
+MyCheckMemoryLeaks (void)
+{
+  memory_block *block;
+
+  if (live_blocks == NULL)
+    return;
+
+  fprintf (stderr, "\nFreedroid internal memory tracker: %zu leak(s), %zu byte(s) still live"
+           " (peak tracked usage %zu byte(s)).\n",
+           live_count, live_bytes, peak_bytes);
+
+  block = live_blocks;
+  while (block != NULL)
+    {
+      memory_block *next = block->next;
+      fprintf (stderr, "  leak: %zu byte(s) allocated at %s:%d (%p)\n",
+               block->size, block->file, block->line, block->ptr);
+      free (block->ptr);
+      free (block);
+      block = next;
+    }
+
+  live_blocks = NULL;
+  live_bytes = 0;
+  live_count = 0;
+}

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -559,7 +559,7 @@ not resolve.... Sorry, if that interrupts a major game of yours.....\n\
   ReadValueFromString (Data, DIGIT_THREE_POSITION_X_STRING, "%hd", &ThirdDigit_Rect.x);
   ReadValueFromString (Data, DIGIT_THREE_POSITION_Y_STRING, "%hd", &ThirdDigit_Rect.y);
 
-  free (Data);
+  MyFree (Data);
 
   return;
 
@@ -1731,7 +1731,7 @@ FreeGraphics ( void )
 
   size_t num_raw_mem = sizeof(portrait_raw_mem)/sizeof(portrait_raw_mem[0]);
   for ( size_t i = 0; i < num_raw_mem; i++) {
-    free ( portrait_raw_mem[i] );
+    MyFree ( portrait_raw_mem[i] );
   }
 
   FD_DestroyWindow ();
@@ -1776,7 +1776,7 @@ FreeGraphics ( void )
     if ( fonts[i] != NULL ) {
         SDL_FreeSurface ( fonts[i]->Surface );
       }
-    free ( fonts[i] );
+    MyFree ( fonts[i] );
   }
 
   // free Load_Block()-internal buffer

--- a/src/highscore.c
+++ b/src/highscore.c
@@ -155,7 +155,7 @@ UpdateHighscores (void)
     return;
 
   /* ok, the last one always has to go... */
-  free (Highscores[num_highscores-1]);
+  MyFree (Highscores[num_highscores-1]);
 
   /* now shuffle down the lower scores to make space */
   for (i=num_highscores-1; i> entry; i--)
@@ -191,7 +191,7 @@ UpdateHighscores (void)
 #if !defined ANDROID
   tmp_name = GetString (MAX_NAME_LEN, 2);
   strcpy (new_entry->name, tmp_name);
-  free (tmp_name);
+  MyFree (tmp_name);
 #else
   strcpy (new_entry->name, "Player");
 #endif

--- a/src/init.c
+++ b/src/init.c
@@ -1352,6 +1352,16 @@ FreeGameMem ( void )
 {
   int i, j;
 
+  for ( i = 0; i < MAX_THEMES; i++ )
+    {
+      if ( AllThemes.theme_name[i] != NULL )
+        {
+          MyFree ( AllThemes.theme_name[i] );
+          AllThemes.theme_name[i] = NULL;
+        }
+    }
+  AllThemes.num_themes = 0;
+
   // free bullet map
   if ( Bulletmap != NULL )
     {

--- a/src/init.c
+++ b/src/init.c
@@ -457,7 +457,7 @@ Init_Game_Data ( const char * Datafilename )
   ReadValueFromString (Data, BLAST_TWO_TOTAL_AMOUNT_OF_TIME_STRING, "%f", &Blastmap[1].total_animation_time);
 
 
-  free ( Data );
+  MyFree ( Data );
 
   return;
 
@@ -737,7 +737,7 @@ InitNewMission ( const char *MissionName )
   // must be read in as well
   ReadValueFromString (MainMissionPointer, MISSION_ENDTITLE_SONG_NAME_STRING, "%s", DebriefingSong);
 
-  if (DebriefingText) free(DebriefingText);
+  if (DebriefingText) MyFree(DebriefingText);
   DebriefingText =
     ReadAndMallocStringFromData (MainMissionPointer, MISSION_ENDTITLE_BEGIN_STRING, MISSION_ENDTITLE_END_STRING);
 
@@ -830,7 +830,7 @@ InitNewMission ( const char *MissionName )
 
   DebugPrintf (1, "done."); // this matches the printf at the beginning of this function
 
-  free (MainMissionPointer);
+  MyFree (MainMissionPointer);
 
   return;
 
@@ -999,7 +999,7 @@ Title ( const char *MissionBriefingPointer )
 	  Terminate(ERR);
 	}
       ThisTextLength=TerminationPointer-NextSubsectionStartPointer;
-      free ( PreparedBriefingText );
+      MyFree ( PreparedBriefingText );
       PreparedBriefingText = MyMalloc (ThisTextLength + 10);
       strncpy ( PreparedBriefingText , NextSubsectionStartPointer , ThisTextLength );
       PreparedBriefingText[ThisTextLength]=0;
@@ -1012,7 +1012,7 @@ Title ( const char *MissionBriefingPointer )
       }
     } // while(1)
 
-  free ( PreparedBriefingText );
+  MyFree ( PreparedBriefingText );
   PreparedBriefingText = NULL;
   return;
 
@@ -1185,7 +1185,7 @@ FindAllThemes (void)
   AllThemes.num_themes = 0;
   for (i=0; i< MAX_THEMES; i++)
     {
-      if (AllThemes.theme_name[i]) free(AllThemes.theme_name[i]);
+      if (AllThemes.theme_name[i]) MyFree(AllThemes.theme_name[i]);
       AllThemes.theme_name[i] = NULL;
     }
 
@@ -1339,9 +1339,9 @@ FreeDruidmap ( void )
   }
   int i;
   for (i=0; i < Number_Of_Droid_Types; i++) {
-    free (Druidmap[i].notes);
+    MyFree (Druidmap[i].notes);
   }
-  free(Druidmap);
+  MyFree(Druidmap);
   Druidmap = NULL;
 
   return;
@@ -1361,7 +1361,7 @@ FreeGameMem ( void )
           SDL_FreeSurface ( Bulletmap[i].SurfacePointer[j] );
         }
       }
-      free ( Bulletmap );
+      MyFree ( Bulletmap );
       Bulletmap = NULL;
     }
 
@@ -1381,14 +1381,14 @@ FreeGameMem ( void )
   // free highscores list
   if ( Highscores != NULL ) {
     for ( i = 0; i < num_highscores; i ++ ) {
-      free ( Highscores[i] );
+      MyFree ( Highscores[i] );
     }
-    free ( Highscores );
+    MyFree ( Highscores );
     Highscores = NULL;
   }
 
   // free constant text blobs
-  free ( DebriefingText );
+  MyFree ( DebriefingText );
   DebriefingText = NULL;
 
   return;

--- a/src/map.c
+++ b/src/map.c
@@ -265,7 +265,7 @@ LoadShip (char *filename)
   Buffer = ReadAndMallocStringFromData (ShipData, AREA_NAME_STRING, "\"");
   strncpy (curShip.AreaName, Buffer, 99);
   curShip.AreaName[99]='\0';
-  free (Buffer);
+  MyFree (Buffer);
 
   //--------------------
   // Now we count the number of levels and remember their start-addresses.
@@ -299,7 +299,7 @@ LoadShip (char *filename)
       InterpretMap (curShip.AllLevels[i]); // initialize doors, refreshes and lifts
     }
 
-  free (ShipData);
+  MyFree (ShipData);
 
   return OK;
 
@@ -505,7 +505,7 @@ freedroid-discussion@lists.sourceforge.net\n\
       LevelMem = StructToMem(curShip.AllLevels[array_num]);
       fwrite(LevelMem, strlen(LevelMem), sizeof(char), ShipFile);
 
-      free(LevelMem);
+      MyFree(LevelMem);
     }
 
   //--------------------
@@ -1079,7 +1079,7 @@ GetLiftConnections (char *filename)
 
   curShip.num_lifts = Label;
 
-  free ( Data );
+  MyFree ( Data );
   return OK;
 }; // int GetLiftConnections(char *shipname)
 
@@ -1153,7 +1153,7 @@ GetCrew (char *filename)
       NumEnemys++;
     }
 
-  free ( MainDroidsFilePointer );
+  MyFree ( MainDroidsFilePointer );
   return (OK);
 } /* GetCrew () */
 
@@ -1796,13 +1796,13 @@ FreeLevelMemory ( level* lvl )
     return;
   }
 
-  free ( lvl->Levelname );
-  free ( lvl->Background_Song_Name );
-  free ( lvl->Level_Enter_Comment );
+  MyFree ( lvl->Levelname );
+  MyFree ( lvl->Background_Song_Name );
+  MyFree ( lvl->Level_Enter_Comment );
 
   int row;
   for ( row = 0; row < lvl->ylen; row ++ ) {
-    free ( lvl->map[row] );
+    MyFree ( lvl->map[row] );
   }
   return;
 }
@@ -1813,7 +1813,7 @@ FreeShipMemory ( void )
   int i;
   for (i = 0; i < curShip.num_levels; i++) {
     FreeLevelMemory ( curShip.AllLevels[i] );
-    free ( curShip.AllLevels[i] );
+    MyFree ( curShip.AllLevels[i] );
   }
 
   return;

--- a/src/menu.c
+++ b/src/menu.c
@@ -537,7 +537,7 @@ const char *handle_LE_SizeX ( MenuAction_t action )
   int row;
   for ( row = 0 ; row < CurLevel->ylen ; row++ )
     {
-      CurLevel->map[row] = realloc( CurLevel->map[row], newmem );
+      CurLevel->map[row] = MyRealloc( CurLevel->map[row], newmem );
       if ( CurLevel->map[row] == NULL ) {
         DebugPrintf ( 0, "Failed to re-allocate to %z bytes in map row %d\n", newmem, row );
         Terminate(ERR);
@@ -562,7 +562,7 @@ const char *handle_LE_SizeY ( MenuAction_t action )
   menuChangeInt ( action, &(CurLevel->ylen), 1, 0, MAX_MAP_ROWS-1 );
   if ( oldylen > CurLevel->ylen )
     {
-      free ( CurLevel->map[oldylen - 1] );
+      MyFree ( CurLevel->map[oldylen - 1] );
       CurLevel->map[oldylen - 1] = NULL;
     }
   else if ( oldylen < CurLevel->ylen )
@@ -585,7 +585,7 @@ const char *handle_LE_Name ( MenuAction_t action )
     {
       DisplayText ("New level name: ", Menu_Rect.x-2*fheight, Menu_Rect.y - 3*fheight, &Full_User_Rect );
       SDL_UpdateWindowSurface(FD_GetWindow());
-      free ( CurLevel->Levelname );
+      MyFree ( CurLevel->Levelname );
       CurLevel->Levelname = GetString(15, 2);
       InitiateMenu (FALSE);
     }
@@ -603,7 +603,7 @@ const char *handle_LE_Music ( MenuAction_t action )
     {
       DisplayText ("Music filename: ", Menu_Rect.x - 2*fheight, Menu_Rect.y - 3*fheight, &Full_User_Rect);
       SDL_UpdateWindowSurface(FD_GetWindow());
-      free ( CurLevel->Background_Song_Name );
+      MyFree ( CurLevel->Background_Song_Name );
       CurLevel->Background_Song_Name = GetString(20, 2);
       Switch_Background_Music_To ( CurLevel->Background_Song_Name );
     }
@@ -1295,7 +1295,7 @@ Cheatmenu (void)
 	  printf_SDL (ne_screen, -1, -1, "New zoom factor: ");
 	  input = GetString (40, 2);
 	  sscanf (input, "%f", &CurrentCombatScaleFactor);
-	  free (input);
+	  MyFree (input);
 	  SetCombatScaleTo (CurrentCombatScaleFactor);
 	  break;
 
@@ -1393,7 +1393,7 @@ Cheatmenu (void)
 	  printf_SDL (ne_screen, x0, y0, "Enter Level, X, Y: ");
 	  input = GetString (40, 2);
 	  sscanf (input, "%d, %d, %d\n", &LNum, &X, &Y);
-	  free (input);
+	  MyFree (input);
 	  Teleport (LNum, X, Y);
 	  break;
 
@@ -1420,7 +1420,7 @@ Cheatmenu (void)
 	      printf_SDL (ne_screen, x0, y0+20, "You are now a %s. Have fun!\n", input);
 	      getchar_raw ();
 	    }
-	  free (input);
+	  MyFree (input);
 	  break;
 
 	case 'i': /* togge Invincible mode */
@@ -1433,7 +1433,7 @@ Cheatmenu (void)
 	  printf_SDL (ne_screen, -1, -1, "Enter your new energy: ");
 	  input = GetString (40, 2);
 	  sscanf (input, "%d", &num);
-	  free (input);
+	  MyFree (input);
 	  Me.energy = (float) num;
 	  if (Me.energy > Me.health) Me.health = Me.energy;
 	  break;
@@ -1450,7 +1450,7 @@ Cheatmenu (void)
 	  printf_SDL (ne_screen, -1, -1, "\nLevelnum: ");
 	  input = GetString (40, 2);
 	  sscanf (input, "%d", &LNum);
-	  free (input);
+	  MyFree (input);
 	  ShowDeckMap ();
 	  getchar_raw ();
 	  break;

--- a/src/misc.c
+++ b/src/misc.c
@@ -227,7 +227,7 @@ LoadGameConfig (void)
     {
       DebugPrintf (0, "WARNING: error in reading config-file %s\n Giving up...", fname);
       fclose (fp);
-      free (data);
+      MyFree (data);
       return (ERR);
     }
 #endif
@@ -237,7 +237,7 @@ LoadGameConfig (void)
   if ( read_variable (data, VERSION_STRING, "%s", version_string) == ERR)
     {
       DebugPrintf (0, "Version string could not be read in config-file...\n");
-      free (data);
+      MyFree (data);
       return (ERR);
     }
 
@@ -270,7 +270,7 @@ LoadGameConfig (void)
       }
     }
 
-  free (data);
+  MyFree (data);
 
   return (OK);
 
@@ -1086,35 +1086,12 @@ Terminate (int ExitCode)
 
   // ----- exit
   DebugPrintf(0, "Thank you for playing Freedroid.\n\n");
+  MyCheckMemoryLeaks ();
   SDL_Quit();
   exit (ExitCode);
   return;
 }  // void Terminate(int ExitCode)
 
-
-/*@Function============================================================
-@Desc: This function usese calloc, so memory is automatically 0-initialized!
-       The function also checks for success and terminates in case of
-       "out of memory", so we dont need to do this always in the code.
-@Ret:
-* $Function----------------------------------------------------------*/
-void *
-MyMalloc (long Mamount)
-{
-  void *Mptr = NULL;
-
-  // make Gnu-compatible even if on a broken system:
-  if (Mamount == 0)
-    Mamount = 1;
-
-  if ((Mptr = calloc (1, (size_t) Mamount)) == NULL)
-    {
-      DebugPrintf (0, " MyMalloc(%ld) did not succeed!\n", Mamount);
-      Terminate(ERR);
-    }
-
-  return Mptr;
-}				// void* MyMalloc(long Mamount)
 
 /*----------------------------------------------------------------------
  * FS_filelength().. (taken from quake2)

--- a/src/proto.h
+++ b/src/proto.h
@@ -286,7 +286,15 @@ EXTERN int MyRandom (int);
 EXTERN void Armageddon (void);
 EXTERN void Teleport (int LNum, int X, int Y);
 EXTERN void Terminate (int);
-EXTERN void *MyMalloc (long);
+EXTERN void *MyMallocLong (long, const char *, int);
+EXTERN void *MyCallocLong (size_t, size_t, const char *, int);
+EXTERN void *MyReallocLong (void *, size_t, const char *, int);
+EXTERN void MyFreeLong (void *, const char *, int);
+EXTERN void MyCheckMemoryLeaks (void);
+#define MyMalloc(n) MyMallocLong((n), __FILE__, __LINE__)
+#define MyCalloc(m, n) MyCallocLong((m), (n), __FILE__, __LINE__)
+#define MyRealloc(p, n) MyReallocLong((p), (n), __FILE__, __LINE__)
+#define MyFree(p) MyFreeLong((p), __FILE__, __LINE__)
 EXTERN size_t FS_filelength (FILE *f);
 EXTERN void init_progress (const char *txt);
 EXTERN void update_progress (int percent);


### PR DESCRIPTION
- import internal memory-leak/violation tracker from LALSuite (GPLed)
- use everywhere to alloc/free memory and check memory-leak at exist by default (framerate not affected at 499fps, so no point doing it coniditionally)
-  related to #46 but I while 'asan' also throws some memleaks (wrt SDL2), the internal memleak tracker finds nothing (after fixing a small leak)